### PR TITLE
Optimizations, and ferram's first attempt at using github

### DIFF
--- a/Plugins/Source/ModularFuelPartModule.cs
+++ b/Plugins/Source/ModularFuelPartModule.cs
@@ -1,0 +1,60 @@
+﻿//#define DEBUG
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using UnityEngine;
+using KSP;
+
+namespace ModularFuelTanks
+{
+    //Use this class to handle any functions needed by all ModularFuels parts
+    public class ModularFuelPartModule : PartModule
+    {
+        [KSPField(isPersistant = true)]
+        protected double timestamp = 0.0;
+
+        protected double precisionDeltaTime = 0.0;
+
+        public static ModularFuelPartModule controllerModule = null;
+        public static double controllerTimeStamp = 0.0;
+        public static double controllerPrecisionDeltaTime = 0.0;
+
+        //This makes sure that every frame the timestep is determined only once; all other Modular Fuel parts then use that timestep for all operations
+        //This function must occur AFTER part-specific functions that are dependent on it if you also want to use precisionDeltaTime for persistence purposes
+        public override void OnUpdate()
+        {
+            base.OnUpdate();
+
+            //If the controller module isn't assigned, assign it; we cast to object because that is faster than the standard == null function, which involves Unity checking if the object was destroyed in addition to being null
+            if ((object)controllerModule == null)
+                controllerModule = this;
+
+            //Here the controller does the floating point math
+            if (controllerModule == this)
+            {
+                double tempTimeStamp = Planetarium.GetUniversalTime();
+                controllerPrecisionDeltaTime = tempTimeStamp - controllerTimeStamp;
+                controllerTimeStamp = tempTimeStamp;
+            }
+            precisionDeltaTime = controllerPrecisionDeltaTime;      //Assign the deltaTime for each part from the static field, so that this field can also be used for handling persistence stuff
+        }
+
+        public void OnDestroy()
+        {
+            controllerModule = null;
+        }
+
+        public override void OnSave(ConfigNode node)
+        {
+            timestamp = controllerTimeStamp;        //This ensures that the timestamp is saved for when the thing initially loads, so that "persistence" effects can be handled; do it before things are saved
+            base.OnSave(node);
+        }
+
+        public override void OnStart(PartModule.StartState state)
+        {
+            base.OnStart(state);
+            precisionDeltaTime = Planetarium.GetUniversalTime() - timestamp;        //This allows us to handle persistence by calculating the deltaTime between "now" and the last time this part was loaded
+        }
+    }
+}

--- a/Plugins/Source/RefuelingPump.cs
+++ b/Plugins/Source/RefuelingPump.cs
@@ -8,10 +8,8 @@ using KSP;
 
 namespace ModularFuelTanks
 {
-	public class RefuelingPump: PartModule
+	public class RefuelingPump : ModularFuelPartModule
 	{
-		[KSPField(isPersistant = true)]
-		double timestamp = 0.0;
 
 		[KSPField(isPersistant = true)]
 		double pump_rate = 100.0; // 625 liters/second seems reasonable.
@@ -23,35 +21,37 @@ namespace ModularFuelTanks
 
 		public override void OnUpdate ()
 		{
-			if (HighLogic.LoadedSceneIsEditor) {
+            if (HighLogic.LoadedSceneIsEditor)
+            {
 
-			} else if (timestamp > 0 && part.parent != null && part.parent.Modules.Contains ("ModuleFuelTanks")) {
-				// We're connected to a fuel tank, so let's top off any depleting resources
+            }
+            else if (timestamp > 0 && part.parent != null && part.parent.Modules.Contains("ModuleFuelTanks"))
+            {
+                // We're connected to a fuel tank, so let's top off any depleting resources
+                FillAttachedTanks(precisionDeltaTime);
+            }
+            base.OnUpdate();            //Needs to be at the end to prevent weird things from happening during startup and to make handling persistance easy; this does mean that the effects are delayed by a frame, but since they're constant, that shouldn't matter here
+        }
 
-				// first, get the time since the last OnUpdate()
-				double delta_t = Planetarium.GetUniversalTime () - timestamp;
 
-				// now, let's look at what we're connected to.
-				ModuleFuelTanks m = (ModuleFuelTanks) part.parent.Modules["ModuleFuelTanks"];
+        private void FillAttachedTanks(double deltaTime)
+        {
+            // now, let's look at what we're connected to.
+            ModuleFuelTanks m = (ModuleFuelTanks)part.parent.Modules["ModuleFuelTanks"];
 
-				// look through all tanks inside this part
-				foreach(ModuleFuelTanks.FuelTank tank in m.fuelList) {
-					// if a tank isn't full, start filling it.
-					if(tank.amount < tank.maxAmount) {
-						double top_off = delta_t * pump_rate;
-						if(tank.amount + top_off < tank.maxAmount)
-							tank.amount += top_off;
-						else
-							tank.amount = tank.maxAmount;
-					}
-
-				}
-				// save the time so we can tell how much time has passed on the next update, even in Warp
-				timestamp = Planetarium.GetUniversalTime ();
-			} else {
-				// save the time so we can tell how much time has passed on the next update, even in Warp
-				timestamp = Planetarium.GetUniversalTime ();
-			}
-		}
+            // look through all tanks inside this part
+            foreach (ModuleFuelTanks.FuelTank tank in m.fuelList)
+            {
+                // if a tank isn't full, start filling it.
+                if (tank.amount < tank.maxAmount)
+                {
+                    double top_off = deltaTime * pump_rate;
+                    if (tank.amount + top_off < tank.maxAmount)
+                        tank.amount += top_off;
+                    else
+                        tank.amount = tank.maxAmount;
+                }
+            }
+        }
 	}
 }

--- a/Plugins/Source/modularFuelTanks.csproj
+++ b/Plugins/Source/modularFuelTanks.csproj
@@ -30,22 +30,21 @@
     <WarningLevel>4</WarningLevel>
     <ConsolePause>False</ConsolePause>
   </PropertyGroup>
-  <ItemGroup>
-    <Reference Include="Assembly-CSharp">
-      <HintPath>../../../KSP_linux/KSP_Data/Managed\Assembly-CSharp.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="UnityEngine">
-      <HintPath>../../../KSP_linux/KSP_Data/Managed\UnityEngine.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-  </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <ItemGroup>
     <Compile Include="AssemblyInfo.cs" />
     <Compile Include="HeatPump.cs" />
+    <Compile Include="ModularFuelPartModule.cs" />
     <Compile Include="ModularFuelTanks.cs" />
     <Compile Include="RefuelingPump.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <Reference Include="Assembly-CSharp">
+      <HintPath>..\..\..\..\..\Games\KSP 0.23 Real Life\KSP_Data\Managed\Assembly-CSharp.dll</HintPath>
+    </Reference>
+    <Reference Include="UnityEngine">
+      <HintPath>..\..\..\..\..\Games\KSP 0.23 Real Life\KSP_Data\Managed\UnityEngine.dll</HintPath>
+    </Reference>
   </ItemGroup>
   <PropertyGroup>
     <PreBuildEvent>


### PR DESCRIPTION
Alright, this includes some optimization changes; most of them are pretty small, but it does reduce the overhead a tiny bit.

The new ModularFuelsPartModule is intended to handle any functions and variables that are needed by multiple PartModules; inherit from that instead of PartModule if a particular class needs that.  Currently, the MFPM class only handles the high-precision timestamping needed for volatile fuel boiloff and the refueling pump, but it can be expanded as needed.  As a side-effect of how it's currently set up, the MFPM causes all of this stuff to be done one frame later than in the original implementation in order to simplify handling fueling / boiloff due to persistence; this can be fixed but would require a large amount of recoding to ensure that all MFS fuel tanks are set up properly before OnStart is called (for the refueling pumps to work).

Also, hopefully I didn't botch my first attempt using github.
