### PR TITLE
Update zSolidFuelMult.cfg

### DIFF
--- a/RealFuels/zSolidFuelMult.cfg
+++ b/RealFuels/zSolidFuelMult.cfg
@@ -1,4 +1,4 @@
-@PART[*]:HAS[!MODULE[ModuleEngineConfigs],@RESOURCE[SolidFuel]]:FINAL
+@PART[*]:HAS[!MODULE[ModuleEngineConfigs],@RESOURCE[SolidFuel]]:NEEDS[!RealismOverhaul]:FINAL
 {
 	@RESOURCE[SolidFuel]
 	{


### PR DESCRIPTION
Adds a tag to NOT increase SolidFuel when RealismOverhaul is installed.
