### PR TITLE
Updated MM config for KW Rocketry v2.6d2.

### DIFF
--- a/ModularFuelTanks/KW_modularFuelTanks.cfg
+++ b/ModularFuelTanks/KW_modularFuelTanks.cfg
@@ -41,6 +41,20 @@
 	}
 }
 
+@PART[KW1mtankL0_5]
+{
+	//!RESOURCE[LiquidFuel] {}
+	//!RESOURCE[Oxidizer] {}
+	//!RESOURCE[MonoPropellant] {}
+	//!RESOURCE[XenonGas] {}
+	MODULE
+	{
+		name = ModuleFuelTanks
+		volume = 120
+		type = Default
+	}
+}
+
 @PART[KW1mtankL1]
 {
 	//!RESOURCE[LiquidFuel] {}
@@ -50,7 +64,7 @@
 	MODULE
 	{
 		name = ModuleFuelTanks
-		volume = 225
+		volume = 240
 		type = Default
 	}
 }
@@ -64,7 +78,7 @@
 	MODULE
 	{
 		name = ModuleFuelTanks
-		volume = 450
+		volume = 480
 		type = Default
 	}
 }
@@ -78,7 +92,7 @@
 	MODULE
 	{
 		name = ModuleFuelTanks
-		volume = 900
+		volume = 960
 		type = Default
 	}
 }
@@ -106,7 +120,7 @@
 	MODULE
 	{
 		name = ModuleFuelTanks
-		volume = 750
+		volume = 800
 		type = RCSHighEfficiency
 	}
 }
@@ -125,6 +139,20 @@
 	}
 }
 
+@PART[KW2mtankL0_5]
+{
+	//!RESOURCE[LiquidFuel] {}
+	//!RESOURCE[Oxidizer] {}
+	//!RESOURCE[MonoPropellant] {}
+	//!RESOURCE[XenonGas] {}
+	MODULE
+	{
+		name = ModuleFuelTanks
+		volume = 960
+		type = Default
+	}
+}
+
 @PART[KW2mtankL1]
 {
 	//!RESOURCE[LiquidFuel] {}
@@ -134,7 +162,7 @@
 	MODULE
 	{
 		name = ModuleFuelTanks
-		volume = 1800
+		volume = 1920
 		type = Default
 	}
 }
@@ -149,7 +177,7 @@
 	MODULE
 	{
 		name = ModuleFuelTanks
-		volume = 3600
+		volume = 3840
 		type = Default
 	}
 }
@@ -164,7 +192,21 @@
 	MODULE
 	{
 		name = ModuleFuelTanks
-		volume = 7200
+		volume = 7680
+		type = Default
+	}
+}
+
+@PART[KW2mtankL4A]
+{
+	//!RESOURCE[LiquidFuel] {}
+	//!RESOURCE[Oxidizer] {}
+	//!RESOURCE[MonoPropellant] {}
+	//!RESOURCE[XenonGas] {}
+	MODULE
+	{
+		name = ModuleFuelTanks
+		volume = 7680
 		type = Default
 	}
 }
@@ -192,7 +234,7 @@
 	MODULE
 	{
 		name = ModuleFuelTanks
-		volume = 1000
+		volume = 2700
 		type = RCSHighEfficiency
 	}
 }
@@ -211,6 +253,20 @@
 	}
 }
 
+@PART[KW3mtankL0_5]
+{
+	//!RESOURCE[LiquidFuel] {}
+	//!RESOURCE[Oxidizer] {}
+	//!RESOURCE[MonoPropellant] {}
+	//!RESOURCE[XenonGas] {}
+	MODULE
+	{
+		name = ModuleFuelTanks
+		volume = 3240
+		type = Default
+	}
+}
+
 @PART[KW3mtankL1]
 {
 	//!RESOURCE[LiquidFuel] {}
@@ -220,8 +276,8 @@
 	MODULE
 	{
 		name = ModuleFuelTanks
-		volume = 6075
-		type = Cryogenic
+		volume = 6480
+		type = Default
 	}
 }
 
@@ -235,7 +291,7 @@
 	MODULE
 	{
 		name = ModuleFuelTanks
-		volume = 12150
+		volume = 12960
 		type = Default
 	}
 }
@@ -250,12 +306,12 @@
 	MODULE
 	{
 		name = ModuleFuelTanks
-		volume = 24300
+		volume = 25920
 		type = Default
 	}
 }
 
-@PART[KW3mtankL4ALT]
+@PART[KW3mtankL4A]
 {
 	//!RESOURCE[LiquidFuel] {}
 	//!RESOURCE[Oxidizer] {}
@@ -264,10 +320,53 @@
 	MODULE
 	{
 		name = ModuleFuelTanks
-		volume = 24300
-		type = Cryogenic
+		volume = 25920
+		type = Default
 	}
 }
+
+@PART[KW5mtankL05]
+{
+	//!RESOURCE[LiquidFuel] {}
+	//!RESOURCE[Oxidizer] {}
+	//!RESOURCE[MonoPropellant] {}
+	//!RESOURCE[XenonGas] {}
+	MODULE
+	{
+		name = ModuleFuelTanks
+		volume = 7680
+		type = Default
+	}
+}
+
+@PART[KW5mtankL1_5]
+{
+	//!RESOURCE[LiquidFuel] {}
+	//!RESOURCE[Oxidizer] {}
+	//!RESOURCE[MonoPropellant] {}
+	//!RESOURCE[XenonGas] {}
+	MODULE
+	{
+		name = ModuleFuelTanks
+		volume = 23040
+		type = Default
+	}
+}
+
+@PART[KW5mtankL3_5]
+{
+	//!RESOURCE[LiquidFuel] {}
+	//!RESOURCE[Oxidizer] {}
+	//!RESOURCE[MonoPropellant] {}
+	//!RESOURCE[XenonGas] {}
+	MODULE
+	{
+		name = ModuleFuelTanks
+		volume = 53760
+		type = Default
+	}
+}
+
 @PART[KW1Sidetank]
 {
 	//!RESOURCE[LiquidFuel] {}
@@ -318,7 +417,7 @@
 	MODULE
 	{
 		name = ModuleFuelTanks
-		volume = 1125
+		volume = 1239.131
 		type = Default
 	}
 }
@@ -346,7 +445,7 @@
 	MODULE
 	{
 		name = ModuleFuelTanks
-		volume = 4125
+		volume = 4719.317
 		type = Default
 	}
 }
@@ -359,7 +458,7 @@
 	MODULE
 	{
 		name = ModuleFuelTanks
-		volume = 2070
+		volume = 2308.323
 		type = Default
 	}
 }
@@ -373,7 +472,7 @@
 	MODULE
 	{
 		name = ModuleFuelTanks
-		volume = 3000
+		volume = 3373.975
 		type = Default
 	}
 }
@@ -387,7 +486,35 @@
 	MODULE
 	{
 		name = ModuleFuelTanks
-		volume = 750
+		volume = 1625.031
+		type = Default
+	}
+}
+
+@PART[KWFuelAdapter5x2]
+{
+	//!RESOURCE[LiquidFuel] {}
+	//!RESOURCE[Oxidizer] {}
+	//!RESOURCE[MonoPropellant] {}
+	//!RESOURCE[XenonGas] {}
+	MODULE
+	{
+		name = ModuleFuelTanks
+		volume = 7027.64
+		type = Default
+	}
+}
+
+@PART[KWFuelAdapter5x3]
+{
+	//!RESOURCE[LiquidFuel] {}
+	//!RESOURCE[Oxidizer] {}
+	//!RESOURCE[MonoPropellant] {}
+	//!RESOURCE[XenonGas] {}
+	MODULE
+	{
+		name = ModuleFuelTanks
+		volume = 5296.398
 		type = Default
 	}
 }


### PR DESCRIPTION
Updated MM config for KW Rocketry v2.6d2:
* added missing tanks (5m, unpainted and L0.5 tanks)
* changed volumes to match KW rebalancing

also
* changed "Cryogenic" tanks to "Default"

Note: Some volumes now have decimal fractions in volume, which may not be desirable.