### PR TITLE
Add NEEDS[!RealismOverhaul] to TantaresLV tanks

### DIFF
--- a/RealFuels/TantaresLV.cfg
+++ b/RealFuels/TantaresLV.cfg
@@ -1,4 +1,4 @@
-@PART[ALV_Engine_A]:FOR[RealFuels]
+@PART[ALV_Engine_A]:NEEDS[!RealismOverhaul]:FOR[RealFuels]
 {
 	MODULE
 	{
@@ -8,7 +8,7 @@
 	}
 }
 
-@PART[ALV_LFO_A]:FOR[RealFuels]
+@PART[ALV_LFO_A]:NEEDS[!RealismOverhaul]:FOR[RealFuels]
 {
 	MODULE
 	{
@@ -17,7 +17,7 @@
 		type = Default
 	}
 }
-@PART[ALV_LFO_A]:FOR[RealFuels]
+@PART[ALV_LFO_A]:NEEDS[!RealismOverhaul]:FOR[RealFuels]
 {
 	MODULE
 	{
@@ -27,7 +27,7 @@
 	}
 }
 
-@PART[TLV_LFO_A]:FOR[RealFuels]
+@PART[TLV_LFO_A]:NEEDS[!RealismOverhaul]:FOR[RealFuels]
 {
 	MODULE
 	{
@@ -36,7 +36,7 @@
 		type = Default
 	}
 }
-@PART[TLV_LFO_B]:FOR[RealFuels]
+@PART[TLV_LFO_B]:NEEDS[!RealismOverhaul]:FOR[RealFuels]
 {
 	MODULE
 	{
@@ -45,7 +45,7 @@
 		type = Default
 	}
 }
-@PART[TLV_LFO_C]:FOR[RealFuels]
+@PART[TLV_LFO_C]:NEEDS[!RealismOverhaul]:FOR[RealFuels]
 {
 	MODULE
 	{
@@ -54,7 +54,7 @@
 		type = Default
 	}
 }
-@PART[TLV_LFO_D]:FOR[RealFuels]
+@PART[TLV_LFO_D]:NEEDS[!RealismOverhaul]:FOR[RealFuels]
 {
 	MODULE
 	{


### PR DESCRIPTION
I should've done this in the first place, to prevent accidental conflicts.