### PR TITLE
Replacing "&" with "," for the newest ModuleManager

### DIFF
--- a/RealFuels/KSPI_RF.cfg
+++ b/RealFuels/KSPI_RF.cfg
@@ -8,7 +8,7 @@
 }
 
 //Add water tank using KSPI water. (TO-DO: integration with TACLS water without trampling KSPI or TACLS)
-@TANK_DEFINITION[*]:HAS[@TANK[Kerosene]&!TANK[LqdWater]]:NEEDS[WarpPlugin]:FOR[RealFuels]
+@TANK_DEFINITION[*]:HAS[@TANK[Kerosene],!TANK[LqdWater]]:NEEDS[WarpPlugin]:FOR[RealFuels]
 {
 	+TANK[Kerosene]
 	{
@@ -17,7 +17,7 @@
 }
 
 //Add Argon to all tanks that have XenonGas, as they function & store similarly.
-@TANK_DEFINITION[*]:HAS[@TANK[XenonGas]&!TANK[Argon]]:NEEDS[WarpPlugin]:FOR[RealFuels]
+@TANK_DEFINITION[*]:HAS[@TANK[XenonGas],!TANK[Argon]]:NEEDS[WarpPlugin]:FOR[RealFuels]
 {
 	+TANK[XenonGas]
 	{
@@ -136,7 +136,7 @@
 }
 
 //Specific part fixes
-@PART[FNMethaneTank*]:HAS[@RESOURCE[LqdMethane]&@RESOURCE[Oxidizer]&!MODULE[ModuleFuelTanks]]:NEEDS[WarpPlugin]:FOR[RealFuels]
+@PART[FNMethaneTank*]:HAS[@RESOURCE[LqdMethane],@RESOURCE[Oxidizer],!MODULE[ModuleFuelTanks]]:NEEDS[WarpPlugin]:FOR[RealFuels]
 {
 	MODULE
 	{
@@ -165,7 +165,7 @@
 }
 
 //NOTE: the ratio might be kinda screwy; this should really go in an engines config.
-@PART[AluminiumHybrid1]:NEEDS[WarpPlugin]:FOR[RealFuels] 
+@PART[AluminiumHybrid1]:NEEDS[WarpPlugin]:FOR[RealFuels]
 {
 	@MODULE[ModuleEngines]
 	{


### PR DESCRIPTION
The KSPI file seems to be the only one that used the "&" operator. Simple find-and-replace.