### PR TITLE
Missing tanks for stock, RetroFuture, and SXT

### DIFF
--- a/RealFuels/RSCapsuledyne.cfg
+++ b/RealFuels/RSCapsuledyne.cfg
@@ -1,9 +1,11 @@
+//multiplied volume by 5 as per Real Fuels conversion standards
+
 @PART[Size3TinyTank]:FOR[RealFuels] // Taurus SM
 {
   MODULE
   {
     name = ModuleFuelTanks
-    volume = 1800
+    volume = 9000
     type = ServiceModule
   }
 }

--- a/RealFuels/RealFuels_MkIVSystem.cfg
+++ b/RealFuels/RealFuels_MkIVSystem.cfg
@@ -1,3 +1,6 @@
+//For Nertea's Mark Iv System
+//added a missing tank
+
 @PART[mk4cargo-1]
 {
 	MODULE
@@ -49,6 +52,15 @@
 	{
 		name = ModuleFuelTanks
 		volume = 8000
+		type = Fuselage
+	}
+}
+@PART[mk4fuselage-lfo-2]
+{
+	MODULE
+	{
+		name = ModuleFuelTanks
+		volume = 12500
 		type = Fuselage
 	}
 }

--- a/RealFuels/RetroFuture_modularFuelTanks.cfg
+++ b/RealFuels/RetroFuture_modularFuelTanks.cfg
@@ -1,4 +1,5 @@
 //camlost
+//added rect4M, 1mBicouplerSmall, 2mHoodAdpter, med2mTailB as Fuselage
 @PART[rect1m]:FOR[RealFuels]
 {
 	!MODULE[FSfuelSwitch] {}
@@ -55,6 +56,18 @@
 	{
 		name = ModuleFuelTanks
 		volume = 2000
+		type = Fuselage
+	}
+}
+
+@PART[rect4M]:FOR[RealFuels]
+{
+	!MODULE[FSfuelSwitch] {}
+	!MODULE[ModuleFuelTanks] {}
+	MODULE
+	{
+		name = ModuleFuelTanks
+		volume = 7920
 		type = Fuselage
 	}
 }
@@ -143,6 +156,18 @@
 	}
 }
 
+@PART[med2mTailB]:FOR[RealFuels]
+{
+	!MODULE[FSfuelSwitch] {}
+	!MODULE[ModuleFuelTanks] {}
+	MODULE
+	{
+		name = ModuleFuelTanks
+		volume = 1100
+		type = Fuselage
+	}
+}
+
 @PART[structBoom]:FOR[RealFuels]
 {
 	!MODULE[FSfuelSwitch] {}
@@ -155,4 +180,26 @@
 	}
 }
 
+@PART[1mBicouplerSmall]:FOR[RealFuels]
+{
+	!MODULE[FSfuelSwitch] {}
+	!MODULE[ModuleFuelTanks] {}
+	MODULE
+	{
+		name = ModuleFuelTanks
+		volume = 275
+		type = Fuselage
+	}
+}
 
+@PART[2mHoodAdpter]:FOR[RealFuels]
+{
+	!MODULE[FSfuelSwitch] {}
+	!MODULE[ModuleFuelTanks] {}
+	MODULE
+	{
+		name = ModuleFuelTanks
+		volume = 410 
+		type = Fuselage
+	}
+}

--- a/RealFuels/SXT.cfg
+++ b/RealFuels/SXT.cfg
@@ -1,3 +1,5 @@
+//added a few parts for SXT release 20
+
 @PART[SXT375mA]:FOR[RealFuels]
 {
 	MODULE
@@ -106,7 +108,7 @@
 	{
 		name = ModuleFuelTanks
 		volume = 22800
-		type = BalloonCryo
+		type = ServiceModule
 	}
 }
 
@@ -137,17 +139,15 @@
 		type = Default
 	}
 }
-
 @PART[SXTradialFuel]:FOR[RealFuels]
 {
 	MODULE
 	{
 		name = ModuleFuelTanks
 		volume = 1333
-		type = Default
+		type = ServiceModule
 	}
 }
-
 @PART[LFUELM3]:FOR[RealFuels]
 {
 	!MODULE[FSfuelSwitch]{}
@@ -155,7 +155,7 @@
 	{
 		name = ModuleFuelTanks
 		volume = 8000
-		type = Default
+		type = ServiceModule
 	}
 }
 @PART[LSmallFuelMod]:FOR[RealFuels]
@@ -165,10 +165,9 @@
 	{
 		name = ModuleFuelTanks
 		volume = 2775
-		type = Default
+		type = ServiceModule
 	}
 }
-
 @PART[SXTKDBTsar25to375]:FOR[RealFuels]
 {
 	MODULE
@@ -205,7 +204,6 @@
 		type = Cryogenic
 	}
 }
-
 @PART[SXT5mTank0]:FOR[RealFuels]
 {
 	MODULE
@@ -242,7 +240,6 @@
 		type = Cryogenic
 	}
 }
-
 @PART[SXTSmallFuselage]:FOR[RealFuels]
 {
 	MODULE
@@ -252,7 +249,6 @@
 		type = Fuselage
 	}
 }
-
 @PART[LMiniAircaftTail]:FOR[RealFuels]
 {
 	MODULE
@@ -262,23 +258,39 @@
 		type = Fuselage
 	}
 }
-
 @PART[SXTBalloonGoldB375]:FOR[RealFuels]
 {
 	MODULE
 	{
 		name = ModuleFuelTanks
 		volume = 18465
-		type = Fuselage
+		type = ServiceModule
 	}
 }
-
 @PART[SXTtruckfueltank]:FOR[RealFuels]
 {
 	MODULE
 	{
 		name = ModuleFuelTanks
 		volume = 2000
+		type = Fuselage
+	}
+}
+@PART[SXTsmallbicoupleradaptor]:FOR[RealFuels]
+{
+	MODULE
+	{
+		name = ModuleFuelTanks
+		volume = 500
+		type = Fuselage
+	}
+}
+@PART[SXTmk2adaptorIntake]:FOR[RealFuels]
+{
+	MODULE
+	{
+		name = ModuleFuelTanks
+		volume = 1000
 		type = Fuselage
 	}
 }

--- a/RealFuels/SpaceplanesPlus.cfg
+++ b/RealFuels/SpaceplanesPlus.cfg
@@ -1,5 +1,6 @@
 // Reworked for 0.25 SPP integration
 // With correct volumes for part sizes (calced based on stretchies at 87% utilization)
+// Updated for 0.90 with more fuselage parts
 
 @PART[mk2Fuselage]:FOR[RealFuels]
 {
@@ -55,7 +56,7 @@
 	{
 		name = ModuleFuelTanks
 		volume = 5900
-		type = Default
+		type = Fuselage
 	}
 }
 
@@ -65,7 +66,7 @@
 	{
 		name = ModuleFuelTanks
 		volume = 3000
-		type = Default
+		type = Fuselage
 	}
 }
 
@@ -75,7 +76,7 @@
 	{
 		name = ModuleFuelTanks
 		volume = 6420
-		type = Default
+		type = Fuselage
 	}
 }
 
@@ -85,7 +86,7 @@
 	{
 		name = ModuleFuelTanks
 		volume = 6420
-		type = Default
+		type = Fuselage
 	}
 }
 
@@ -95,7 +96,7 @@
 	{
 		name = ModuleFuelTanks
 		volume = 4000
-		type = Default
+		type = Fuselage
 	}
 }
 

--- a/RealFuels/Squad_modularFuelTanks.cfg
+++ b/RealFuels/Squad_modularFuelTanks.cfg
@@ -1,3 +1,5 @@
+//added missing Mk3 Fuselages, various spaceplane adapters as Fuselages
+
 @PART[fuelTank]:FOR[RealFuels]
 {
 	MODULE
@@ -24,7 +26,7 @@
 	{
 		name = ModuleFuelTanks
 		volume = 16000
-		type = Default
+		type = Cryogenic
 	}
 }
 
@@ -34,7 +36,7 @@
 	{
 		name = ModuleFuelTanks
 		volume = 8000
-		type = Default
+		type = Cryogenic
 	}
 }
 
@@ -54,7 +56,7 @@
 	{
 		name = ModuleFuelTanks
 		volume = 4000
-		type = Default
+		type = Cryogenic
 	}
 }
 
@@ -119,6 +121,146 @@
 	}
 }
 
+@PART[mk3FuselageMONO]:FOR[RealFuels]
+{
+	MODULE
+	{
+		name = ModuleFuelTanks
+		volume = 5000
+		type = ServiceModule
+	}
+}
+
+@PART[mk3FuselageLFO_50]:FOR[RealFuels]
+{
+	MODULE
+	{
+		name = ModuleFuelTanks
+		volume = 25000
+		type = Fuselage
+	}
+}
+
+@PART[mk3FuselageLFO_100]:FOR[RealFuels]
+{
+	MODULE
+	{
+		name = ModuleFuelTanks
+		volume = 50000
+		type = Fuselage
+	}
+}
+
+@PART[mk3FuselageLFO_25]:FOR[RealFuels]
+{
+	MODULE
+	{
+		name = ModuleFuelTanks
+		volume = 12500
+		type = Fuselage
+	}
+}
+
+@PART[mk3FuselageLF_100]:FOR[RealFuels]
+{
+	MODULE
+	{
+		name = ModuleFuelTanks
+		volume = 50000
+		type = Fuselage
+	}
+}
+
+@PART[mk3FuselageLF_50]:FOR[RealFuels]
+{
+	MODULE
+	{
+		name = ModuleFuelTanks
+		volume = 25000
+		type = Fuselage
+	}
+}
+
+@PART[mk3FuselageLF_25]:FOR[RealFuels]
+{
+	MODULE
+	{
+		name = ModuleFuelTanks
+		volume = 12500
+		type = Fuselage
+	}
+}
+
+@PART[adapterSize3-Mk3]:FOR[RealFuels]
+{
+	MODULE
+	{
+		name = ModuleFuelTanks
+		volume = 12500
+		type = Fuselage
+	}
+}
+
+@PART[adapterSize2-Size1Slant]:FOR[RealFuels]
+{
+	MODULE
+	{
+		name = ModuleFuelTanks
+		volume = 4000
+		type = Cryogenic
+	}
+}
+
+@PART[adapterSize2-Size1]:FOR[RealFuels]
+{
+	MODULE
+	{
+		name = ModuleFuelTanks
+		volume = 4000
+		type = Cryogenic
+	}
+}
+
+@PART[adapterSize2-Mk2]:FOR[RealFuels]
+{
+	MODULE
+	{
+		name = ModuleFuelTanks
+		volume = 4000
+		type = Fuselage
+	}
+}
+
+@PART[adapterMk3-Size2Slant]:FOR[RealFuels]
+{
+	MODULE
+	{
+		name = ModuleFuelTanks
+		volume = 12500
+		type = Cryogenic
+	}
+}
+
+@PART[adapterMk3-Size2]:FOR[RealFuels]
+{
+	MODULE
+	{
+		name = ModuleFuelTanks
+		volume = 12500
+		type = Cryogenic
+	}
+}
+
+@PART[adapterMk3-Mk2]:FOR[RealFuels]
+{
+	MODULE
+	{
+		name = ModuleFuelTanks
+		volume = 10000
+		type = Fuselage
+	}
+}
+
 @PART[radialRCSTank]:FOR[RealFuels]
 {
 	MODULE
@@ -155,7 +297,7 @@
 	{
 		name = ModuleFuelTanks
 		volume = 1600
-		type = Structural
+		type = Cryogenic
 	}
 }
 
@@ -208,6 +350,7 @@
 		type = Xenon
 	}
 }
+
 @PART[xenonTankRadial]:FOR[RealFuels]
 {
 	MODULE


### PR DESCRIPTION
Hello,

Please let me know if I messed up. Here's a list of things I did:

-Multiplied the RSCapsuledyne's tank by 5 to be more in line with other RF tanks
-Added a bunch of missing Squad Mk3 parts/adapters as Fuselages
-Added a missing Mk IV tank as Fuselage
-Added a couple SXT parts as Fuselages

Question:  How does one go about determining which tanks should be Default/Cryogenic/BalloonCryo/etc.? I know Fuselage/Xenon/ServiceModule is pretty self-explanatory but what about the rest?

For your consideration.