### PR TITLE
Sea Dragon 2 tanks

### DIFF
--- a/RealFuels/Sea_Dragon2_tanks.cfg
+++ b/RealFuels/Sea_Dragon2_tanks.cfg
@@ -1,0 +1,22 @@
+@PART[Tank2]:FOR[RealFuels]
+{
+	MODULE
+	{
+		name = ModuleFuelTanks
+		volume = 3170000
+		type = Cryogenic
+	}
+}
+
+@PART[Tank1]:FOR[RealFuels]
+{
+
+	MODULE
+	{
+		name = ModuleFuelTanks
+		volume = 3170000
+		type = Cryogenic
+		basemass = 8.17035e-5 * volume
+	}
+}
+


### PR DESCRIPTION
Changed volume to more closely match size. Added mass to stage one tank
to give stage one mass fraction similar to "real" sea dragon.