### PR TITLE
MFT & RF support for OPT Space Plane Parts

### DIFF
--- a/ModularFuelTanks/OPT_SPP_modularFuelTanks.cfg
+++ b/ModularFuelTanks/OPT_SPP_modularFuelTanks.cfg
@@ -1,8 +1,9 @@
 @PART[OPTdropTank]
+{
 	MODULE
 	{
 		name = ModuleFuelTanks
-		volume = 1250
+		volume = 250
 		type = Jet
 	}
 	!MODULE[FSfuelSwitch] {}
@@ -13,10 +14,11 @@
 }
 
 @PART[k_cockpit_adaptor]
+{
 	MODULE
 	{
 		name = ModuleFuelTanks
-		volume = 25000
+		volume = 5000
 		type = Fuselage
 		typeAvailable = Fuselage
 		typeAvailable = Structural
@@ -25,10 +27,11 @@
 }
 
 @PART[ij_4m_adaptor]
+{
 	MODULE
 	{
 		name = ModuleFuelTanks
-		volume = 12500
+		volume = 2500
 		type = Fuselage
 		typeAvailable = Fuselage
 		typeAvailable = Structural
@@ -41,10 +44,11 @@
 }
 
 @PART[ij_4m_adaptor_variant]
+{
 	MODULE
 	{
 		name = ModuleFuelTanks
-		volume = 12500
+		volume = 2500
 		type = Fuselage
 		typeAvailable = Fuselage
 		typeAvailable = Structural
@@ -57,10 +61,11 @@
 }
 
 @PART[j_docking_port]
+{
 	MODULE
 	{
 		name = ModuleFuelTanks
-		volume = 3250
+		volume = 650
 		type = Fuselage
 		typeAvailable = Fuselage
 		typeAvailable = Structural
@@ -68,10 +73,11 @@
 }
 
 @PART[j_4m_tanks]
+{
 	MODULE
 	{
 		name = ModuleFuelTanks
-		volume = 16000
+		volume = 3200
 		type = Fuselage
 		typeAvailable = Fuselage
 		typeAvailable = Structural
@@ -84,10 +90,11 @@
 }
 
 @PART[jk_7m_adaptor]
+{
 	MODULE
 	{
 		name = ModuleFuelTanks
-		volume = 25000
+		volume = 5000
 		type = Fuselage
 		typeAvailable = Fuselage
 		typeAvailable = Structural
@@ -96,10 +103,11 @@
 }
 
 @PART[js_adaptor]
+{
 	MODULE
 	{
 		name = ModuleFuelTanks
-		volume = 1000
+		volume = 200
 		type = Fuselage
 		typeAvailable = Fuselage
 		typeAvailable = Structural
@@ -107,10 +115,11 @@
 }
 
 @PART[k_6m_tanks]
+{
 	MODULE
 	{
 		name = ModuleFuelTanks
-		volume = 24000
+		volume = 4800
 		type = Fuselage
 		typeAvailable = Fuselage
 		typeAvailable = Structural
@@ -119,46 +128,51 @@
 }
 
 @PART[k_cockpit]
+{
 	MODULE
 	{
 		name = ModuleFuelTanks
-		volume = 2250
+		volume = 450
 		type = Fuselage
 	}
 }
 
 @PART[i_4m_cockpit_isp]
+{
 	MODULE
 	{
 		name = ModuleFuelTanks
-		volume = 400
+		volume = 80
 		type = Fuselage
 	}
 }
 
 @PART[ils_cockpit]
+{
 	MODULE
 	{
 		name = ModuleFuelTanks
-		volume = 200
+		volume = 40
 		type = Fuselage
 	}
 }
 
 @PART[mk23_cockpit]
+{
 	MODULE
 	{
 		name = ModuleFuelTanks
-		volume = 500
+		volume = 100
 		type = Fuselage
 	}
 }
 
 @PART[j_cockpit]
+{
 	MODULE
 	{
 		name = ModuleFuelTanks
-		volume = 200
+		volume = 40
 		type = Fuselage
 	}
 }

--- a/RealFuels/OPT_SPP_modularFuelTanks.cfg
+++ b/RealFuels/OPT_SPP_modularFuelTanks.cfg
@@ -6,9 +6,13 @@
 	{
 		name = ModuleFuelTanks
 		volume = 1250
-		type = Default
+		type = Jet
 	}
-	-MODULE[FSfuelSwitch]
+	!MODULE[FSfuelSwitch] {}
+	@MODULE[FSmeshSwitch]
+	{
+		@useFuelSwitchModule = false
+	}
 }
 
 @PART[k_cockpit_adaptor]:FOR[RealFuels]
@@ -18,8 +22,10 @@
 		name = ModuleFuelTanks
 		volume = 25000
 		type = Fuselage
+		typeAvailable = Fuselage
+		typeAvailable = Structural
 	}
-	-MODULE[FSfuelSwitch]
+	!MODULE[FSfuelSwitch] {}
 }
 
 @PART[ij_4m_adaptor]:FOR[RealFuels]
@@ -29,8 +35,14 @@
 		name = ModuleFuelTanks
 		volume = 12500
 		type = Fuselage
+		typeAvailable = Fuselage
+		typeAvailable = Structural
 	}
-	-MODULE[FSfuelSwitch]
+	!MODULE[FSfuelSwitch] {}
+	@MODULE[FSmeshSwitch]
+	{
+		@useFuelSwitchModule = false
+	}
 }
 
 @PART[ij_4m_adaptor_variant]:FOR[RealFuels]
@@ -40,8 +52,14 @@
 		name = ModuleFuelTanks
 		volume = 12500
 		type = Fuselage
+		typeAvailable = Fuselage
+		typeAvailable = Structural
 	}
-	-MODULE[FSfuelSwitch]
+	!MODULE[FSfuelSwitch] {}
+	@MODULE[FSmeshSwitch]
+	{
+		@useFuelSwitchModule = false
+	}
 }
 
 @PART[j_docking_port]:FOR[RealFuels]
@@ -51,6 +69,8 @@
 		name = ModuleFuelTanks
 		volume = 3250
 		type = Fuselage
+		typeAvailable = Fuselage
+		typeAvailable = Structural
 	}
 }
 
@@ -61,8 +81,14 @@
 		name = ModuleFuelTanks
 		volume = 16000
 		type = Fuselage
+		typeAvailable = Fuselage
+		typeAvailable = Structural
 	}
-	-MODULE[FSfuelSwitch]
+	!MODULE[FSfuelSwitch] {}
+	@MODULE[FSmeshSwitch]
+	{
+		@useFuelSwitchModule = false
+	}
 }
 
 @PART[jk_7m_adaptor]:FOR[RealFuels]
@@ -72,8 +98,10 @@
 		name = ModuleFuelTanks
 		volume = 25000
 		type = Fuselage
+		typeAvailable = Fuselage
+		typeAvailable = Structural
 	}
-	-MODULE[FSfuelSwitch]
+	!MODULE[FSfuelSwitch] {}
 }
 
 @PART[js_adaptor]:FOR[RealFuels]
@@ -83,6 +111,8 @@
 		name = ModuleFuelTanks
 		volume = 1000
 		type = Fuselage
+		typeAvailable = Fuselage
+		typeAvailable = Structural
 	}
 }
 
@@ -93,8 +123,10 @@
 		name = ModuleFuelTanks
 		volume = 24000
 		type = Fuselage
+		typeAvailable = Fuselage
+		typeAvailable = Structural
 	}
-	-MODULE[FSfuelSwitch]
+	!MODULE[FSfuelSwitch] {}
 }
 
 @PART[k_cockpit]:FOR[RealFuels]

--- a/RealFuels/OPT_SPP_modularFuelTanks.cfg
+++ b/RealFuels/OPT_SPP_modularFuelTanks.cfg
@@ -1,0 +1,149 @@
+// Remove FSFuelSwitcher bits.
+
+@PART[OPTdropTank]:FOR[RealFuels]
+{
+	MODULE
+	{
+		name = ModuleFuelTanks
+		volume = 1250
+		type = Default
+	}
+	-MODULE[FSfuelSwitch]
+}
+
+@PART[k_cockpit_adaptor]:FOR[RealFuels]
+{
+	MODULE
+	{
+		name = ModuleFuelTanks
+		volume = 25000
+		type = Fuselage
+	}
+	-MODULE[FSfuelSwitch]
+}
+
+@PART[ij_4m_adaptor]:FOR[RealFuels]
+{
+	MODULE
+	{
+		name = ModuleFuelTanks
+		volume = 12500
+		type = Fuselage
+	}
+	-MODULE[FSfuelSwitch]
+}
+
+@PART[ij_4m_adaptor_variant]:FOR[RealFuels]
+{
+	MODULE
+	{
+		name = ModuleFuelTanks
+		volume = 12500
+		type = Fuselage
+	}
+	-MODULE[FSfuelSwitch]
+}
+
+@PART[j_docking_port]:FOR[RealFuels]
+{
+	MODULE
+	{
+		name = ModuleFuelTanks
+		volume = 3250
+		type = Fuselage
+	}
+}
+
+@PART[j_4m_tanks]:FOR[RealFuels]
+{
+	MODULE
+	{
+		name = ModuleFuelTanks
+		volume = 16000
+		type = Fuselage
+	}
+	-MODULE[FSfuelSwitch]
+}
+
+@PART[jk_7m_adaptor]:FOR[RealFuels]
+{
+	MODULE
+	{
+		name = ModuleFuelTanks
+		volume = 25000
+		type = Fuselage
+	}
+	-MODULE[FSfuelSwitch]
+}
+
+@PART[js_adaptor]:FOR[RealFuels]
+{
+	MODULE
+	{
+		name = ModuleFuelTanks
+		volume = 1000
+		type = Fuselage
+	}
+}
+
+@PART[k_6m_tanks]:FOR[RealFuels]
+{
+	MODULE
+	{
+		name = ModuleFuelTanks
+		volume = 24000
+		type = Fuselage
+	}
+	-MODULE[FSfuelSwitch]
+}
+
+@PART[k_cockpit]:FOR[RealFuels]
+{
+	MODULE
+	{
+		name = ModuleFuelTanks
+		volume = 2250
+		type = Fuselage
+	}
+}
+
+@PART[i_4m_cockpit_isp]:FOR[RealFuels]
+{
+	MODULE
+	{
+		name = ModuleFuelTanks
+		volume = 400
+		type = Fuselage
+	}
+}
+
+@PART[ils_cockpit]:FOR[RealFuels]
+{
+	MODULE
+	{
+		name = ModuleFuelTanks
+		volume = 200
+		type = Fuselage
+	}
+}
+
+@PART[mk23_cockpit]:FOR[RealFuels]
+{
+	MODULE
+	{
+		name = ModuleFuelTanks
+		volume = 500
+		type = Fuselage
+	}
+}
+
+@PART[j_cockpit]:FOR[RealFuels]
+{
+	MODULE
+	{
+		name = ModuleFuelTanks
+		volume = 200
+		type = Fuselage
+	}
+}
+


### PR DESCRIPTION
I built a config that replaces OPT SPP's built-in FSfuelSwitcher with RF/MFT. Basically, it removes FSfuelSwitcher where it's used, decouples FSmeshSwitcher where that module is in use, and adds MFT and RF tanks respectively to the parts whenever there's fuel in them. Most parts use Fuselage as their default, but have Structural available. The drop tank is of type Jet, since it seems intended for atmospheric use mainly. Cockpits are of type Fuselage. If there's a better suggestion for those, I'm all ears.