### PR TITLE
Sea Dragon 2 tanks

### DIFF
--- a/RealFuels/Sea_Dragon2_tanks.cfg
+++ b/RealFuels/Sea_Dragon2_tanks.cfg
@@ -1,0 +1,22 @@
+@PART[Tank2]:FOR[RealFuels]
+{
+	MODULE
+	{
+		name = ModuleFuelTanks
+		volume = 3170000
+		type = Cryogenic
+	}
+}
+
+@PART[Tank1]:FOR[RealFuels]
+{
+
+	MODULE
+	{
+		name = ModuleFuelTanks
+		volume = 3170000
+		type = Cryogenic
+		basemass = 8.17035e-5 * volume
+	}
+}
+

--- a/RealFuels/Sea_Dragon2_tanks.cfg
+++ b/RealFuels/Sea_Dragon2_tanks.cfg
@@ -15,8 +15,8 @@
 	{
 		name = ModuleFuelTanks
 		volume = 3170000
-		type = Cryogenic
-		basemass = 8.17035e-5 * volume
+		type = Structural
+		basemass = .00008 * volume
 	}
 }
 


### PR DESCRIPTION
Made volume match size when compared to a stretchy tank. Modified Stage 1 tank basemass to give Stage 1 mass fraction similar to "real" Sea Dragon.