### PR TITLE
Update configs for Nertea's MKIV system

### DIFF
--- a/RealFuels/RealFuels_MkIVSystem.cfg
+++ b/RealFuels/RealFuels_MkIVSystem.cfg
@@ -1,94 +1,73 @@
-//For Nertea's Mark Iv System
-//added a missing tank
+//Redo for 2.0.0
 
-@PART[mk4cargo-1]
+@PART[mk4*]:HAS[@RESOURCE[LiquidFuel],!MODULE[ModuleFuelTanks],!MODULE[ModuleCommand]]:NEEDS[RealFuels]:FINAL
 {
-	MODULE
-	{
-		name = ModuleFuelTanks
-		volume = 1000
-		type = Fuselage
-	}
-}
-@PART[mk4cargo-tail-1]
-{
-	MODULE
-	{
-		name = ModuleFuelTanks
-		volume = 500
-		type = Fuselage
-	}
-}
-@PART[mk4adapter-1]
-{
-	MODULE
-	{
-		name = ModuleFuelTanks
-		volume = 4000
-		type = Fuselage
-	}
-}
-@PART[mk4adapter-2]
-{
-	MODULE
-	{
-		name = ModuleFuelTanks
-		volume = 4000
-		type = Fuselage
-	}
-}
-@PART[mk4fuselage-1]
-{
-	MODULE
-	{
-		name = ModuleFuelTanks
-		volume = 8000
-		type = Fuselage
-	}
-}
-@PART[mk4fuselage-lfo-1]
-{
-	MODULE
-	{
-		name = ModuleFuelTanks
-		volume = 8000
-		type = Fuselage
-	}
-}
-@PART[mk4fuselage-lfo-2]
-{
-	MODULE
-	{
-		name = ModuleFuelTanks
-		volume = 12500
-		type = Fuselage
-	}
-}
-@PART[mk4mono-1]
-{
-	MODULE
-	{
-		name = ModuleFuelTanks
-		volume = 3000
-		type = ServiceModule
-	}
-}
-@PART[mk4tail-1]
-{
-	MODULE
-	{
-		name = ModuleFuelTanks
-		volume = 4000
-		type = Fuselage
-	}
-}
-@PART[mk4tail-2]
-{
-	MODULE
-	{
-		name = ModuleFuelTanks
-		volume = 8000
-		type = Fuselage
-	}
+  MODULE
+  {
+    name = ModuleFuelTanks
+    volume = 0
+    @volume = #$/RESOURCE[LiquidFuel]/maxAmount$
+    @volume += #$/RESOURCE[Oxidizer]/maxAmount$
+    @volume *= 5           
+    type = Fuselage
+  }
+
+  !RESOURCE[LiquidFuel] {}
+  !RESOURCE[Oxidizer] {}
+  !MODULE[InterstellarFuelSwitch] {}
+
 }
 
+@PART[mk4*]:HAS[@MODULE[InterstellarFuelSwitch],~category[Utility]]:NEEDS[RealFuels]:FINAL
+{
+  MODULE
+  {
+    name = ModuleFuelTanks
+    volume = 0
+    @volume = #$/MODULE[InterstellarFuelSwitch]/resourceAmounts[0,;]$
+    @volume *= 5
+    type = Fuselage
+  }
+
+  !MODULE[InterstellarFuelSwitch] {}
+
+}
+
+@PART[mk4*]:HAS[@MODULE[InterstellarFuelSwitch],#category[Utility]]:NEEDS[RealFuels]:FINAL
+{
+  MODULE
+  {
+    name = ModuleFuelTanks
+    volume = 0
+    @volume = #$/MODULE[InterstellarFuelSwitch]/resourceAmounts[1,;]$
+    @volume *= 5
+    type = Fuselage
+  }
+
+  !MODULE[InterstellarFuelSwitch] {}
+}
+
+@PART[mk4servicebay-1]:AFTER[RealFuels]
+{
+  MODULE
+  {
+    name = ModuleFuelTanks
+    volume = 3000        
+    type = ServiceModule
+  }
+
+  !RESOURCE[MonoPropellant] {}
+}
+
+@PART[mk4cockpit-1]:AFTER[RealFuels]
+{
+  MODULE
+  {
+    name = ModuleFuelTanks
+    volume = 1300     
+    type = ServiceModule
+    basemass = 5.5
+  }
+
+  !RESOURCE[MonoPropellant] {}
+}

--- a/RealFuels/RealFuels_MkIVSystem.cfg
+++ b/RealFuels/RealFuels_MkIVSystem.cfg
@@ -7,13 +7,11 @@
     name = ModuleFuelTanks
     volume = 0
     @volume = #$/RESOURCE[LiquidFuel]/maxAmount$
-    @volume += #$/RESOURCE[Oxidizer]/maxAmount$
     @volume *= 5           
     type = Fuselage
   }
 
   !RESOURCE[LiquidFuel] {}
-  !RESOURCE[Oxidizer] {}
   !MODULE[InterstellarFuelSwitch] {}
 
 }


### PR DESCRIPTION
Multiplies tank contents by 5 and changes them into a RF tank with the appropriate type, nukes fuel switch but not mesh switch modules.