### PR TITLE
Dev

### DIFF
--- a/RealFuels/Resources/RealTankTypes.cfg
+++ b/RealFuels/Resources/RealTankTypes.cfg
@@ -156,7 +156,7 @@ TANK_DEFINITION
 		fillable = True
 		amount = 0.0
 		maxAmount = 0.0
-		temperature = 195.15
+		temperature = 237.65
 		note = (lacks insulation)
 	}
 	TANK
@@ -167,7 +167,7 @@ TANK_DEFINITION
 		fillable = True
 		amount = 0.0
 		maxAmount = 0.0
-		temperature = 91.15
+		temperature = 111.45
 		note = (lacks insulation)
 	}
 	TANK
@@ -492,7 +492,7 @@ TANK_DEFINITION
 	name = Cryogenic
 	highlyPressurized = False
 	basemass = 0.000019 * volume
-	outerInsulationFactor = 0.025
+	outerInsulationFactor = 0.01
 	TANK
 	{
 		name = LqdOxygen
@@ -501,7 +501,7 @@ TANK_DEFINITION
 		fillable = True
 		amount = 0.0
 		maxAmount = 0.0
-		temperature = 90.15
+		temperature = 90.15		
 		note = (has insulation)
 	}
 	TANK
@@ -645,7 +645,7 @@ TANK_DEFINITION
 		fillable = True
 		amount = 0.0
 		maxAmount = 0.0
-		temperature = 195.15
+		temperature = 237.65
 		wallThickness = 0.01
 		wallConduction = 205
 		insulationThickness = 0.03
@@ -660,7 +660,7 @@ TANK_DEFINITION
 		fillable = True
 		amount = 0.0
 		maxAmount = 0.0
-		temperature = 91.15
+		temperature = 111.45
 		wallThickness = 0.01
 		wallConduction = 205
 		insulationThickness = 0.03
@@ -1177,7 +1177,7 @@ TANK_DEFINITION
 		fillable = True
 		amount = 0.0
 		maxAmount = 0.0
-		temperature = 195.15
+		temperature = 237.65
 		wallThickness = 0.01
 		wallConduction = 205
 		insulationThickness = 0.015
@@ -1192,7 +1192,7 @@ TANK_DEFINITION
 		fillable = True
 		amount = 0.0
 		maxAmount = 0.0
-		temperature = 91.15
+		temperature = 111.45
 		wallThickness = 0.01
 		wallConduction = 205
 		insulationThickness = 0.015
@@ -1867,7 +1867,7 @@ TANK_DEFINITION
 		fillable = True
 		amount = 0.0
 		maxAmount = 0.0
-		temperature = 195.15
+		temperature = 237.65
 		note = (lacks insulation)
 	}
 	TANK
@@ -1878,7 +1878,7 @@ TANK_DEFINITION
 		fillable = True
 		amount = 0.0
 		maxAmount = 0.0
-		temperature = 91.15
+		temperature = 111.45
 		note = (lacks insulation)
 	}
 	TANK
@@ -2393,7 +2393,7 @@ TANK_DEFINITION
 		fillable = True
 		amount = 0.0
 		maxAmount = 0.0
-		temperature = 195.15
+		temperature = 237.65
 		// Next 4 lines need another pass
 		wallThickness = 0.01
 		wallConduction = 205
@@ -2409,7 +2409,7 @@ TANK_DEFINITION
 		fillable = True
 		amount = 0.0
 		maxAmount = 0.0
-		temperature = 91.15
+		temperature = 111.45
 		// Next 4 lines need another pass
 		wallThickness = 0.01
 		wallConduction = 205
@@ -3085,7 +3085,7 @@ TANK_DEFINITION
 		fillable = True
 		amount = 0.0
 		maxAmount = 0.0
-		temperature = 195.15
+		temperature = 237.65
 		note = (lacks insulation)
 	}
 	TANK
@@ -3096,7 +3096,7 @@ TANK_DEFINITION
 		fillable = True
 		amount = 0.0
 		maxAmount = 0.0
-		temperature = 91.15
+		temperature = 111.45
 		note = (lacks insulation)
 	}
 	TANK
@@ -3421,7 +3421,7 @@ TANK_DEFINITION
 	name = BalloonCryo
 	highlyPressurized = False
 	basemass = 0.000005 * volume
-	outerInsulationFactor = 0.025
+	outerInsulationFactor = 0.01
 	TANK
 	{
 		name = LqdOxygen
@@ -3578,7 +3578,7 @@ TANK_DEFINITION
 		fillable = True
 		amount = 0.0
 		maxAmount = 0.0
-		temperature = 195.15
+		temperature = 237.65
 		wallThickness = 0.1
 		wallConduction = 205
 		insulationThickness = 0.03
@@ -3593,7 +3593,7 @@ TANK_DEFINITION
 		fillable = True
 		amount = 0.0
 		maxAmount = 0.0
-		temperature = 91.15
+		temperature = 111.45
 		wallThickness = 0.1
 		wallConduction = 205
 		insulationThickness = 0.03

--- a/RealFuels/Resources/RealTankTypes.cfg
+++ b/RealFuels/Resources/RealTankTypes.cfg
@@ -13,7 +13,6 @@ TANK_DEFINITION
 		amount = 0.0
 		maxAmount = 0.0
 		temperature = 90.15
-		loss_rate = 0.000000005
 		note = (lacks insulation)
 	}
 	TANK
@@ -34,8 +33,11 @@ TANK_DEFINITION
 		amount = 0.0
 		maxAmount = 0.0
 		temperature = 20.15
-		loss_rate = 0.000000017
-		note = (lacks insulation)
+		wallThickness = 0.1
+		wallConduction = 205
+		insulationThickness = 0.03
+		insulationConduction = 0.014
+		note = (basic insulation)
 	}
 	TANK
 	{
@@ -155,7 +157,6 @@ TANK_DEFINITION
 		amount = 0.0
 		maxAmount = 0.0
 		temperature = 195.15
-		loss_rate = 0.0000000002
 		note = (lacks insulation)
 	}
 	TANK
@@ -167,7 +168,6 @@ TANK_DEFINITION
 		amount = 0.0
 		maxAmount = 0.0
 		temperature = 91.15
-		loss_rate = 0.000000005
 		note = (lacks insulation)
 	}
 	TANK
@@ -492,6 +492,7 @@ TANK_DEFINITION
 	name = Cryogenic
 	highlyPressurized = False
 	basemass = 0.000019 * volume
+	outerInsulationFactor = 0.025
 	TANK
 	{
 		name = LqdOxygen
@@ -501,7 +502,6 @@ TANK_DEFINITION
 		amount = 0.0
 		maxAmount = 0.0
 		temperature = 90.15
-		loss_rate = 0.00000000008
 		note = (has insulation)
 	}
 	TANK
@@ -522,7 +522,10 @@ TANK_DEFINITION
 		amount = 0.0
 		maxAmount = 0.0
 		temperature = 20.15
-		loss_rate = 0.0000000005
+		wallThickness = 0.1
+		wallConduction = 205
+		insulationThickness = 0.03
+		insulationConduction = 0.014
 		note = (has insulation)
 	}
 	TANK
@@ -643,7 +646,10 @@ TANK_DEFINITION
 		amount = 0.0
 		maxAmount = 0.0
 		temperature = 195.15
-		loss_rate = 0
+		wallThickness = 0.01
+		wallConduction = 205
+		insulationThickness = 0.03
+		insulationConduction = 0.014
 		note = (has insulation)
 	}
 	TANK
@@ -655,7 +661,10 @@ TANK_DEFINITION
 		amount = 0.0
 		maxAmount = 0.0
 		temperature = 91.15
-		loss_rate = 0.00000000008
+		wallThickness = 0.01
+		wallConduction = 205
+		insulationThickness = 0.03
+		insulationConduction = 0.014
 		note = (has insulation)
 	}
 	TANK
@@ -989,7 +998,10 @@ TANK_DEFINITION
 		amount = 0.0
 		maxAmount = 0.0
 		temperature = 90.15
-		loss_rate = 0.00000000008
+		wallThickness = 0.01
+		wallConduction = 205
+		insulationThickness = 0.015
+		insulationConduction = 0.0001
 		note = (has insulation, pressurized)
 	}
 	TANK
@@ -1011,7 +1023,10 @@ TANK_DEFINITION
 		amount = 0.0
 		maxAmount = 0.0
 		temperature = 20.15
-		loss_rate = 0.0000000005
+		wallThickness = 0.01
+		wallConduction = 205
+		insulationThickness = 0.015
+		insulationConduction = 0.0001
 		note = (has insulation, pressurized)
 	}
 	TANK
@@ -1163,7 +1178,10 @@ TANK_DEFINITION
 		amount = 0.0
 		maxAmount = 0.0
 		temperature = 195.15
-		loss_rate = 0
+		wallThickness = 0.01
+		wallConduction = 205
+		insulationThickness = 0.015
+		insulationConduction = 0.0001
 		note = (has insulation, pressurized)
 	}
 	TANK
@@ -1175,7 +1193,10 @@ TANK_DEFINITION
 		amount = 0.0
 		maxAmount = 0.0
 		temperature = 91.15
-		loss_rate = 0.00000000008
+		wallThickness = 0.01
+		wallConduction = 205
+		insulationThickness = 0.015
+		insulationConduction = 0.0001
 		note = (has insulation, pressurized)
 	}
 	TANK
@@ -1723,7 +1744,10 @@ TANK_DEFINITION
 		amount = 0.0
 		maxAmount = 0.0
 		temperature = 20.15
-		loss_rate = 0.000000017
+		wallThickness = 0.01
+		wallConduction = 205
+		insulationThickness = 0.015
+		insulationConduction = 0.0001
 		note = (lacks insulation)
 	}
 	TANK
@@ -1844,7 +1868,6 @@ TANK_DEFINITION
 		amount = 0.0
 		maxAmount = 0.0
 		temperature = 195.15
-		loss_rate = 0.0000000002
 		note = (lacks insulation)
 	}
 	TANK
@@ -1856,7 +1879,6 @@ TANK_DEFINITION
 		amount = 0.0
 		maxAmount = 0.0
 		temperature = 91.15
-		loss_rate = 0.000000005
 		note = (lacks insulation)
 	}
 	TANK
@@ -2190,7 +2212,11 @@ TANK_DEFINITION
 		amount = 0.0
 		maxAmount = 0.0
 		temperature = 90.15
-		loss_rate = 0.00000000008
+		// Next 4 lines need another pass
+		wallThickness = 0.03
+		wallConduction = 205
+		insulationThickness = 0.03
+		insulationConduction = 0.014
 		note = (has insulation, pressurized)
 	}
 	TANK
@@ -2212,7 +2238,11 @@ TANK_DEFINITION
 		amount = 0.0
 		maxAmount = 0.0
 		temperature = 20.15
-		loss_rate = 0.0000000005
+		// Next 4 lines need another pass
+		wallThickness = 0.03
+		wallConduction = 205
+		insulationThickness = 0.015
+		insulationConduction = 0.0001
 		note = (has insulation, pressurized)
 	}
 	TANK
@@ -2364,7 +2394,11 @@ TANK_DEFINITION
 		amount = 0.0
 		maxAmount = 0.0
 		temperature = 195.15
-		loss_rate = 0
+		// Next 4 lines need another pass
+		wallThickness = 0.01
+		wallConduction = 205
+		insulationThickness = 0.015
+		insulationConduction = 0.0001
 		note = (has insulation, pressurized)
 	}
 	TANK
@@ -2376,7 +2410,11 @@ TANK_DEFINITION
 		amount = 0.0
 		maxAmount = 0.0
 		temperature = 91.15
-		loss_rate = 0.00000000008
+		// Next 4 lines need another pass
+		wallThickness = 0.01
+		wallConduction = 205
+		insulationThickness = 0.015
+		insulationConduction = 0.0001
 		note = (has insulation, pressurized)
 	}
 	TANK
@@ -2924,8 +2962,11 @@ TANK_DEFINITION
 		amount = 0.0
 		maxAmount = 0.0
 		temperature = 20.15
-		loss_rate = 0.000000017
-		note = (lacks insulation)
+		wallThickness = 0.1
+		wallConduction = 205
+		insulationThickness = 0.03
+		insulationConduction = 0.014
+		note = (basic insulation)
 	}
 	TANK
 	{
@@ -3045,7 +3086,6 @@ TANK_DEFINITION
 		amount = 0.0
 		maxAmount = 0.0
 		temperature = 195.15
-		loss_rate = 0.0000000002
 		note = (lacks insulation)
 	}
 	TANK
@@ -3057,7 +3097,6 @@ TANK_DEFINITION
 		amount = 0.0
 		maxAmount = 0.0
 		temperature = 91.15
-		loss_rate = 0.000000005
 		note = (lacks insulation)
 	}
 	TANK
@@ -3382,6 +3421,7 @@ TANK_DEFINITION
 	name = BalloonCryo
 	highlyPressurized = False
 	basemass = 0.000005 * volume
+	outerInsulationFactor = 0.025
 	TANK
 	{
 		name = LqdOxygen
@@ -3391,7 +3431,10 @@ TANK_DEFINITION
 		amount = 0.0
 		maxAmount = 0.0
 		temperature = 90.15
-		loss_rate = 0.00000000008
+		wallThickness = 0.1
+		wallConduction = 205
+		insulationThickness = 0.03
+		insulationConduction = 0.014
 		note = (has insulation)
 	}
 	TANK
@@ -3412,7 +3455,10 @@ TANK_DEFINITION
 		amount = 0.0
 		maxAmount = 0.0
 		temperature = 20.15
-		loss_rate = 0.0000000005
+		wallThickness = 0.1
+		wallConduction = 205
+		insulationThickness = 0.03
+		insulationConduction = 0.014
 		note = (has insulation)
 	}
 	TANK
@@ -3533,7 +3579,10 @@ TANK_DEFINITION
 		amount = 0.0
 		maxAmount = 0.0
 		temperature = 195.15
-		loss_rate = 0
+		wallThickness = 0.1
+		wallConduction = 205
+		insulationThickness = 0.03
+		insulationConduction = 0.014
 		note = (has insulation)
 	}
 	TANK
@@ -3545,7 +3594,10 @@ TANK_DEFINITION
 		amount = 0.0
 		maxAmount = 0.0
 		temperature = 91.15
-		loss_rate = 0.00000000008
+		wallThickness = 0.1
+		wallConduction = 205
+		insulationThickness = 0.03
+		insulationConduction = 0.014
 		note = (has insulation)
 	}
 	TANK

--- a/RealFuels/Resources/ResourceHsps.cfg
+++ b/RealFuels/Resources/ResourceHsps.cfg
@@ -1,0 +1,103 @@
+@RESOURCE_DEFINITION[LqdOxygen]:FOR[RealFuels]
+{
+	%hsp = 918 // specific heat capacity (kJ/tonne-K as units) // recalc, mols are for O2 on wiki
+	%vsp = 213000 // heat of vapourization (KJ/tonne as units)
+}
+@RESOURCE_DEFINITION[LqdHydrogen]:FOR[RealFuels]
+{
+	%hsp = 14305 // specific heat capacity (kJ/tonne-K as units) // recalc, mols are for H2 on wiki
+	%vsp = 448500 // heat of vapourization (KJ/tonne as units)  or 8.97 * 10^5 or 8.97E5?
+}
+@RESOURCE_DEFINITION[Kerosene]:FOR[RealFuels]
+{
+	%hsp = 2010 // specific heat capacity (kJ/tonne-K as units)
+}
+@RESOURCE_DEFINITION[AvGas]:FOR[RealFuels]
+{
+	%hsp = 2220 // specific heat capacity (kJ/tonne-K as units) // http://www.engineeringtoolbox.com/specific-heat-fluids-d_151.html
+}
+@RESOURCE_DEFINITION[Ethanol75]:FOR[RealFuels]
+{
+	%hsp = 3087.5 // specific heat capacity (kJ/tonne-K as units) // 2720 for Ethanol , 4190 for water
+}
+// FIXME do same for MONx
+@RESOURCE_DEFINITION[NTO|MON*]:FOR[RealFuels]
+{
+	%hsp = 1521.6 // specific heat capacity (kJ/tonne-K as units) // http://webbook.nist.gov/cgi/cbook.cgi?ID=C10544726&Type=JANAFL&Plot=on#JANAFL
+}
+@RESOURCE_DEFINITION[MMH]:FOR[RealFuels]
+{
+	%hsp = 2928.8 // specific heat capacity (kJ/tonne-K as units)
+}
+@RESOURCE_DEFINITION[UDMH]:FOR[RealFuels]
+{
+	%hsp = 2729.6 // specific heat capacity (kJ/tonne-K as units) // http://webbook.nist.gov/cgi/cbook.cgi?ID=C10544726&Type=JANAFL&Plot=on#JANAFL
+}
+@RESOURCE_DEFINITION[Hydyne]:FOR[RealFuels]
+{
+	%hsp = 2625 // specific heat capacity (kJ/tonne-K as units) // UDMH + DETA. UDMH is above, DETA is 2466 per wiki. Mix was 60:40, so...
+}
+@RESOURCE_DEFINITION[Hydrazine]:FOR[RealFuels]
+{
+	%hsp = 3120.6 // specific heat capacity (kJ/tonne-K as units) //see Aerozine
+}
+@RESOURCE_DEFINITION[UH25]:FOR[RealFuels]
+{
+	%hsp = 2850 // specific heat capacity (kJ/tonne-K as units) // guesstimate based on Hydrazine and UDMH and AZ50
+}
+@RESOURCE_DEFINITION[Aerozine50]:FOR[RealFuels]
+{
+	%hsp = 2970.1 // specific heat capacity (kJ/tonne-K as units) // http://www.gentoogeek.org/steves_world/hypergol_properties.pdf
+	// hydrazine: http://webbook.nist.gov/cgi/cbook.cgi?ID=C302012&Units=SI&Mask=1A8F&Type=JANAFL&Plot=on#JANAFL - 3120.6
+}
+@RESOURCE_DEFINITION[HTP]:FOR[RealFuels]
+{
+	%hsp = 2721 // specific heat capacity (kJ/tonne-K as units) // http://www.h2o2.com/technical-library/physical-chemical-properties/thermodynamic-properties/default.aspx?pid=36&name=Heat-Capacity
+}
+@RESOURCE_DEFINITION[Nitrogen]:FOR[RealFuels]
+{
+	%hsp = 1039 // specific heat capacity (kJ/tonne-K as units) // http://www.engineeringtoolbox.com/nitrogen-d_977.html
+}
+
+// Amines
+@RESOURCE_DEFINITION[Aniline|Tonka250|Tonka500]:FOR[RealFuels]
+{
+	%hsp = 2180 // specific heat capacity (kJ/tonne-K as units) // http://www.engineeringtoolbox.com/specific-heat-fluids-d_151.html for aniline, copied to others. Note http://pubs.acs.org/doi/abs/10.1021/ja01147a515 disagrees, says Aniline is ~2100.
+}
+
+@RESOURCE_DEFINITION[Furfuryl]:FOR[RealFuels]
+{
+	%hsp = 2096 // specific heat capacity (kJ/tonne-K as units) // http://pubs.acs.org/doi/abs/10.1021/ja01147a515
+}
+
+// Nitric Acid
+@RESOURCE_DEFINITION[IRFNA*|IWFNA||AK20|AK27]:FOR[RealFuels]
+{
+	%hsp = 1720 // specific heat capacity (kJ/tonne-K as units) // http://www.engineeringtoolbox.com/specific-heat-fluids-d_151.html for nitric acid, copied to AKx
+}
+@RESOURCE_DEFINITION[Methanol]:FOR[RealFuels]
+{
+	%hsp = 2510 // specific heat capacity (kJ/tonne-K as units) // http://www.engineeringtoolbox.com/specific-heat-fluids-d_151.html
+}
+@RESOURCE_DEFINITION[Water|WasteWater]:FOR[RealFuels]
+{
+	%hsp = 4183 // specific heat capacity (kJ/tonne-K as units)
+}
+@RESOURCE_DEFINITION[Food|Waste]:FOR[RealFuels]
+{
+	%hsp = 600 // specific heat capacity (kJ/tonne-K as units) // total guess
+}
+@RESOURCE_DEFINITION[LeadBallast]:FOR[RealFuels]
+{
+	%hsp = 128 // specific heat capacity (kJ/tonne-K as units) // http://hyperphysics.phy-astr.gsu.edu/hbase/tables/sphtt.html
+}
+
+// FIXME solid fuel Hsps, for now just 920 like stock
+@RESOURCE_DEFINITION[HTPB|PBAN|PSPC|HNIW|NGNC]:FOR[RealFuels]
+{
+	%hsp = 920 // FIXME, total guess but based on 'standardized' solids and the stock SolidFuel %hsp.
+}
+@RESOURCE_DEFINITION[LqdAmmonia]
+{
+	%vsp = 1373000 // http://www.engineeringtoolbox.com/ammonia-d_1413.html
+}

--- a/Source/RealFuels.csproj
+++ b/Source/RealFuels.csproj
@@ -21,6 +21,11 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <ConsolePause>False</ConsolePause>
+    <CustomCommands>
+      <CustomCommands>
+        <Command type="AfterBuild" command="copy ${ProjectDir}\..\RealFuels\Plugins\RealFuels.dll C:\Games\KSP_win_1.0.4_STOCK\GameData\RealFuels\Plugins" externalConsole="True" />
+      </CustomCommands>
+    </CustomCommands>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>none</DebugType>
@@ -30,6 +35,11 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <ConsolePause>False</ConsolePause>
+    <CustomCommands>
+      <CustomCommands>
+        <Command type="AfterBuild" command="xcopy /y C:\Users\Kevin\Documents\GitHub\ModularFuelSystem\RealFuels\Plugins\RealFuels.dll C:\Games\KSP_win_1.0.4_STOCK\GameData\RealFuels\Plugins\" externalConsole="True" />
+      </CustomCommands>
+    </CustomCommands>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Assembly-CSharp">

--- a/Source/RealFuels.csproj
+++ b/Source/RealFuels.csproj
@@ -10,7 +10,6 @@
     <RootNamespace>RealFuels</RootNamespace>
     <AssemblyName>RealFuels</AssemblyName>
     <TargetFrameworkVersion>v3.5</TargetFrameworkVersion>
-    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>True</DebugSymbols>
@@ -34,24 +33,17 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Assembly-CSharp">
-      <HintPath>..\..\..\..\..\..\Games\KSP_win1\KSP_Data\Managed\Assembly-CSharp.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="KSPAPIExtensions, Version=1.7.2.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\RealFuels\Plugins\KSPAPIExtensions.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="SolverEngines">
-      <HintPath>..\..\SolverEngines\GameData\SolverEngines\Plugins\SolverEngines.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="System, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\..\..\..\..\Games\KSP_win_1.0.4_STOCK\KSP_Data\Managed\Assembly-CSharp.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine">
-      <HintPath>..\..\..\..\..\..\Games\KSP_win1\KSP_Data\Managed\UnityEngine.dll</HintPath>
-      <Private>False</Private>
+      <HintPath>..\..\..\..\..\..\Games\KSP_win_1.0.4_STOCK\KSP_Data\Managed\UnityEngine.dll</HintPath>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="KSPAPIExtensions">
+      <HintPath>..\..\..\..\..\..\Games\KSP_win_1.0.4\GameData\RealFuels\Plugins\KSPAPIExtensions.dll</HintPath>
+    </Reference>
+    <Reference Include="SolverEngines">
+      <HintPath>..\..\..\..\..\..\Games\KSP_win_1.0.4\GameData\SolverEngines\Plugins\SolverEngines.dll</HintPath>
     </Reference>
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
@@ -86,6 +78,6 @@
   <PropertyGroup>
     <PreBuildEvent>cd $(ProjectDir)
 
-sh tools/git-version.sh</PreBuildEvent>
+<!-- sh tools/git-version.sh --></PreBuildEvent>
   </PropertyGroup>
 </Project>

--- a/Source/RealFuels.csproj
+++ b/Source/RealFuels.csproj
@@ -12,7 +12,6 @@
     <TargetFrameworkVersion>v3.5</TargetFrameworkVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <DebugSymbols>false</DebugSymbols>
     <DebugType>none</DebugType>
     <Optimize>False</Optimize>
     <BaseIntermediateOutputPath>..\..\Build\RealFuels\obj\</BaseIntermediateOutputPath>

--- a/Source/RealFuels.sln
+++ b/Source/RealFuels.sln
@@ -1,8 +1,6 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 2013
-VisualStudioVersion = 12.0.21005.1
-MinimumVisualStudioVersion = 10.0.40219.1
+# Visual Studio 2012
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "RealFuels", "RealFuels.csproj", "{0041813D-DCD1-4AC7-8327-85765BF924A3}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TweakScale_RealFuels", "TweakScale_RealFuels.csproj", "{F2B85F9A-6E39-4525-B31F-A3D764DE28D0}"
@@ -22,10 +20,10 @@ Global
 		{F2B85F9A-6E39-4525-B31F-A3D764DE28D0}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{F2B85F9A-6E39-4525-B31F-A3D764DE28D0}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
+	GlobalSection(MonoDevelopProperties) = preSolution
+		StartupItem = RealFuels.csproj
+	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
-	EndGlobalSection
-	GlobalSection(MonoDevelopProperties) = preSolution
-		StartupItem = modularFuelTanks.csproj
 	EndGlobalSection
 EndGlobal

--- a/Source/RealFuels.sln
+++ b/Source/RealFuels.sln
@@ -22,6 +22,37 @@ Global
 	EndGlobalSection
 	GlobalSection(MonoDevelopProperties) = preSolution
 		StartupItem = RealFuels.csproj
+		Policies = $0
+		$0.DotNetNamingPolicy = $1
+		$1.DirectoryNamespaceAssociation = None
+		$1.ResourceNamePolicy = FileFormatDefault
+		$0.TextStylePolicy = $2
+		$2.inheritsSet = VisualStudio
+		$2.inheritsScope = text/plain
+		$2.scope = text/x-csharp
+		$0.CSharpFormattingPolicy = $3
+		$3.IndentSwitchBody = True
+		$3.AnonymousMethodBraceStyle = NextLine
+		$3.PropertyBraceStyle = NextLine
+		$3.PropertyGetBraceStyle = NextLine
+		$3.PropertySetBraceStyle = NextLine
+		$3.EventBraceStyle = NextLine
+		$3.EventAddBraceStyle = NextLine
+		$3.EventRemoveBraceStyle = NextLine
+		$3.StatementBraceStyle = NextLine
+		$3.ArrayInitializerBraceStyle = NextLine
+		$3.BeforeMethodDeclarationParentheses = False
+		$3.BeforeMethodCallParentheses = False
+		$3.BeforeConstructorDeclarationParentheses = False
+		$3.BeforeDelegateDeclarationParentheses = False
+		$3.NewParentheses = False
+		$3.inheritsSet = Mono
+		$3.inheritsScope = text/x-csharp
+		$3.scope = text/x-csharp
+		$0.TextStylePolicy = $4
+		$4.inheritsSet = VisualStudio
+		$4.inheritsScope = text/plain
+		$4.scope = text/plain
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/Source/RealFuels.userprefs
+++ b/Source/RealFuels.userprefs
@@ -1,0 +1,8 @@
+﻿<Properties>
+  <MonoDevelop.Ide.Workspace ActiveConfiguration="Debug" PreferredExecutionTarget="MonoDevelop.Default" />
+  <MonoDevelop.Ide.Workbench />
+  <MonoDevelop.Ide.DebuggingService.Breakpoints>
+    <BreakpointStore />
+  </MonoDevelop.Ide.DebuggingService.Breakpoints>
+  <MonoDevelop.Ide.DebuggingService.PinnedWatches />
+</Properties>

--- a/Source/RealFuels.userprefs
+++ b/Source/RealFuels.userprefs
@@ -1,35 +1,11 @@
 ﻿<Properties>
   <MonoDevelop.Ide.Workspace ActiveConfiguration="Release" PreferredExecutionTarget="MonoDevelop.Default" />
-  <MonoDevelop.Ide.Workbench ActiveDocument="Engines\ModuleEngineConfigs.cs">
+  <MonoDevelop.Ide.Workbench ActiveDocument="c:\Users\Kevin\Documents\GitHub\ModularFuelSystem\Source\Engines\EngineConfigUpgrade.cs">
     <Files>
-      <File FileName="Tanks\ModuleFuelTanks.cs" Line="311" Column="70" />
-      <File FileName="assembly\Checkers.cs" Line="1" Column="1" />
-      <File FileName="tweakscale\TweakScale_ModularEngines.cs" Line="1" Column="1" />
-      <File FileName="Engines\ModuleEnginesRF.cs" Line="85" Column="30" />
-      <File FileName="Tanks\FuelTank.cs" Line="23" Column="9" />
-      <File FileName="Engines\ModuleEngineConfigs.cs" Line="908" Column="30" />
-      <File FileName="Engines\SolverRF.cs" Line="88" Column="17" />
-      <File FileName="TechLevels\TechLevel.cs" Line="280" Column="32" />
-      <File FileName="Utilities\Utilities.cs" Line="144" Column="78" />
+      <File FileName="Tanks\ModuleFuelTanks.cs" Line="371" Column="43" />
+      <File FileName="Engines\ModuleEngineConfigs.cs" Line="438" Column="9" />
+      <File FileName="c:\Users\Kevin\Documents\GitHub\ModularFuelSystem\Source\Engines\EngineConfigUpgrade.cs" Line="22" Column="65" />
     </Files>
-    <Pads>
-      <Pad Id="ProjectPad">
-        <State expanded="True">
-          <Node name="RealFuels" expanded="True">
-            <Node name="assembly" expanded="True" />
-            <Node name="Engines" expanded="True">
-              <Node name="ModuleEngineConfigs.cs" selected="True" />
-            </Node>
-            <Node name="Tanks" expanded="True" />
-            <Node name="TechLevels" expanded="True" />
-            <Node name="Utilities" expanded="True" />
-          </Node>
-          <Node name="TweakScale_RealFuels" expanded="True">
-            <Node name="tweakscale" expanded="True" />
-          </Node>
-        </State>
-      </Pad>
-    </Pads>
   </MonoDevelop.Ide.Workbench>
   <MonoDevelop.Ide.DebuggingService.Breakpoints>
     <BreakpointStore />

--- a/Source/RealFuels.userprefs
+++ b/Source/RealFuels.userprefs
@@ -1,15 +1,28 @@
 ﻿<Properties>
-  <MonoDevelop.Ide.Workspace ActiveConfiguration="Debug" />
+  <MonoDevelop.Ide.Workspace ActiveConfiguration="Release" />
   <MonoDevelop.Ide.Workbench ActiveDocument="Tanks\ModuleFuelTanks.cs">
     <Files>
-      <File FileName="Engines\ModuleEngineConfigs.cs" Line="12" Column="7" />
-      <File FileName="assembly\AssemblyInfoRF.cs" Line="20" Column="32" />
+      <File FileName="Tanks\ModuleFuelTanks.cs" Line="333" Column="100" />
       <File FileName="assembly\Checkers.cs" Line="1" Column="1" />
-      <File FileName="assembly\VersionReport.cs" Line="1" Column="1" />
-      <File FileName="Engines\ModuleEnginesRF.cs" Line="397" Column="21" />
-      <File FileName="Tanks\FuelTank.cs" Line="374" Column="82" />
-      <File FileName="Tanks\ModuleFuelTanks.cs" Line="334" Column="40" />
+      <File FileName="tweakscale\TweakScale_ModularEngines.cs" Line="1" Column="1" />
     </Files>
+    <Pads>
+      <Pad Id="ProjectPad">
+        <State expanded="True">
+          <Node name="RealFuels" expanded="True">
+            <Node name="References" expanded="True" />
+            <Node name="assembly" expanded="True" />
+            <Node name="Engines" expanded="True" />
+            <Node name="Tanks" expanded="True">
+              <Node name="ModuleFuelTanks.cs" selected="True" />
+            </Node>
+          </Node>
+          <Node name="TweakScale_RealFuels" expanded="True">
+            <Node name="tweakscale" expanded="True" />
+          </Node>
+        </State>
+      </Pad>
+    </Pads>
   </MonoDevelop.Ide.Workbench>
   <MonoDevelop.Ide.DebuggingService.Breakpoints>
     <BreakpointStore />

--- a/Source/RealFuels.userprefs
+++ b/Source/RealFuels.userprefs
@@ -1,21 +1,28 @@
 ﻿<Properties>
-  <MonoDevelop.Ide.Workspace ActiveConfiguration="Release" />
-  <MonoDevelop.Ide.Workbench ActiveDocument="Tanks\ModuleFuelTanks.cs">
+  <MonoDevelop.Ide.Workspace ActiveConfiguration="Release" PreferredExecutionTarget="MonoDevelop.Default" />
+  <MonoDevelop.Ide.Workbench ActiveDocument="Engines\ModuleEngineConfigs.cs">
     <Files>
-      <File FileName="Tanks\ModuleFuelTanks.cs" Line="333" Column="100" />
+      <File FileName="Tanks\ModuleFuelTanks.cs" Line="311" Column="70" />
       <File FileName="assembly\Checkers.cs" Line="1" Column="1" />
       <File FileName="tweakscale\TweakScale_ModularEngines.cs" Line="1" Column="1" />
+      <File FileName="Engines\ModuleEnginesRF.cs" Line="85" Column="30" />
+      <File FileName="Tanks\FuelTank.cs" Line="23" Column="9" />
+      <File FileName="Engines\ModuleEngineConfigs.cs" Line="908" Column="30" />
+      <File FileName="Engines\SolverRF.cs" Line="88" Column="17" />
+      <File FileName="TechLevels\TechLevel.cs" Line="280" Column="32" />
+      <File FileName="Utilities\Utilities.cs" Line="144" Column="78" />
     </Files>
     <Pads>
       <Pad Id="ProjectPad">
         <State expanded="True">
           <Node name="RealFuels" expanded="True">
-            <Node name="References" expanded="True" />
             <Node name="assembly" expanded="True" />
-            <Node name="Engines" expanded="True" />
-            <Node name="Tanks" expanded="True">
-              <Node name="ModuleFuelTanks.cs" selected="True" />
+            <Node name="Engines" expanded="True">
+              <Node name="ModuleEngineConfigs.cs" selected="True" />
             </Node>
+            <Node name="Tanks" expanded="True" />
+            <Node name="TechLevels" expanded="True" />
+            <Node name="Utilities" expanded="True" />
           </Node>
           <Node name="TweakScale_RealFuels" expanded="True">
             <Node name="tweakscale" expanded="True" />

--- a/Source/RealFuels.userprefs
+++ b/Source/RealFuels.userprefs
@@ -1,6 +1,16 @@
 ﻿<Properties>
-  <MonoDevelop.Ide.Workspace ActiveConfiguration="Debug" PreferredExecutionTarget="MonoDevelop.Default" />
-  <MonoDevelop.Ide.Workbench />
+  <MonoDevelop.Ide.Workspace ActiveConfiguration="Debug" />
+  <MonoDevelop.Ide.Workbench ActiveDocument="Tanks\ModuleFuelTanks.cs">
+    <Files>
+      <File FileName="Engines\ModuleEngineConfigs.cs" Line="12" Column="7" />
+      <File FileName="assembly\AssemblyInfoRF.cs" Line="20" Column="32" />
+      <File FileName="assembly\Checkers.cs" Line="1" Column="1" />
+      <File FileName="assembly\VersionReport.cs" Line="1" Column="1" />
+      <File FileName="Engines\ModuleEnginesRF.cs" Line="397" Column="21" />
+      <File FileName="Tanks\FuelTank.cs" Line="374" Column="82" />
+      <File FileName="Tanks\ModuleFuelTanks.cs" Line="334" Column="40" />
+    </Files>
+  </MonoDevelop.Ide.Workbench>
   <MonoDevelop.Ide.DebuggingService.Breakpoints>
     <BreakpointStore />
   </MonoDevelop.Ide.DebuggingService.Breakpoints>

--- a/Source/Tanks/FuelTank.cs
+++ b/Source/Tanks/FuelTank.cs
@@ -216,7 +216,8 @@ namespace RealFuels.Tanks
 			node.AddValue ("amount", value);
 			node.AddValue ("maxAmount", value);
 #if DEBUG
-			print (node.ToString ());
+			// TODO Fix this Starwaster!
+			// print (node.ToString ());
 #endif
 			partResource = part.AddResource (node);
 			partResource.enabled = true;

--- a/Source/Tanks/FuelTank.cs
+++ b/Source/Tanks/FuelTank.cs
@@ -20,7 +20,9 @@ namespace RealFuels.Tanks
 	// mass         How much the part's mass is increased per volume unit
 	//              of tank installed for this resource type. Tons per
 	//              volume unit.
-	// loss_rate    How quickly this resource type bleeds out of the tank.
+	// loss_rate    How quickly this resource type bleeds out of the tank. 
+    //
+    //
 
 	public class FuelTank: IConfigNode
 	{
@@ -35,8 +37,24 @@ namespace RealFuels.Tanks
 		public float mass = 0.0f;
 		[Persistent]
 		public float cost = 0.0f;
+        // TODO Retaining for fallback purposes but should be deprecated eventually
 		[Persistent]
 		public double loss_rate = 0.0;
+        // representing conduction factor from Fourier conduction formula. 
+        public double vsp;
+
+        //[Persistent]
+        //public double conductivity = 205.0; // default is 205 for aluminum 10cm thick (205 * 0.1m)
+
+        //[Persistent]
+        public double wallThickness = 0.1;
+        //[Persistent]
+        public double wallConduction = 205; // Aluminum conductive factor
+        //[Persistent]
+        public double insulationThickness = 0.0;
+        //[Persistent]
+        public double insulationConduction = 1.0;
+
 		[Persistent]
 		public float temperature = 300.0f;
 		[Persistent]
@@ -216,12 +234,7 @@ namespace RealFuels.Tanks
 			node.AddValue ("amount", value);
 			node.AddValue ("maxAmount", value);
 #if DEBUG
-<<<<<<< HEAD
-			// TODO Fix this Starwaster!
-			// print (node.ToString ());
-=======
 			MonoBehaviour.print (node.ToString ());
->>>>>>> NathanKell/master
 #endif
 			partResource = part.AddResource (node);
 			partResource.enabled = true;
@@ -305,6 +318,8 @@ namespace RealFuels.Tanks
 			maxAmountExpression = node.GetValue ("maxAmount") ?? maxAmountExpression;
 
 			resourceAvailable = PartResourceLibrary.Instance.GetDefinition (name) != null;
+            MFSSettings.resourceVsps.TryGetValue(name, out vsp);
+
 
             GetDensity();
 		}

--- a/Source/Tanks/ModuleFuelTanks.cs
+++ b/Source/Tanks/ModuleFuelTanks.cs
@@ -326,7 +326,17 @@ namespace RealFuels.Tanks
                 {
                     FuelTank tank = tankList[i];
 
-                    if (tank.loss_rate > 0 && tank.amount > 0)
+					double vsp = 0d;
+
+					if (MFSSettings.resourceVsps.TryGetValue(tank.name, out vsp))
+					{
+						double lossAmount;
+						double massLost = tank.density * lossAmount;
+
+						// subtract heat from boiloff
+						part.AddThermalFlux(massLost * vsp * deltaTimeRecip);
+					}
+					else if (tank.loss_rate > 0 && tank.amount > 0)
                     {
                         double deltaTemp = part.temperature - tank.temperature;
                         if (deltaTemp > 0)
@@ -342,9 +352,9 @@ namespace RealFuels.Tanks
                                 lossAmount = -lossAmount;
                                 tank.amount += lossAmount;
                             }
-                            double vsp = 0d;
                             double massLost = tank.density * lossAmount;
                             boiloffMass += massLost;
+							// TODO Shouldn't actually get here anymore; remove it.
                             if (MFSSettings.resourceVsps.TryGetValue(tank.name, out vsp))
                             {
                                 // subtract heat from boiloff

--- a/Source/Tanks/TankDefinition.cs
+++ b/Source/Tanks/TankDefinition.cs
@@ -24,6 +24,9 @@ namespace RealFuels.Tanks
         [Persistent]
         public bool highlyPressurized = false;
 
+        [Persistent]
+        public string outerInsulationFactor = "1.0";
+
 		public Tanks.FuelTankList tankList = new Tanks.FuelTankList ();
 
 

--- a/Source/TweakScale_RealFuels.csproj
+++ b/Source/TweakScale_RealFuels.csproj
@@ -10,7 +10,6 @@
     <RootNamespace>RealFuels</RootNamespace>
     <AssemblyName>TweakScale_RealFuels</AssemblyName>
     <TargetFrameworkVersion>v3.5</TargetFrameworkVersion>
-    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>True</DebugSymbols>
@@ -51,9 +50,7 @@
       <HintPath>..\..\SolverEngines\GameData\SolverEngines\Plugins\SolverEngines.dll</HintPath>
       <Private>False</Private>
     </Reference>
-    <Reference Include="System">
-      <Private>False</Private>
-    </Reference>
+    <Reference Include="System" />
     <Reference Include="UnityEngine">
       <HintPath>..\..\..\..\..\..\Games\KSP_090clean\KSP_Data\Managed\UnityEngine.dll</HintPath>
       <Private>False</Private>
@@ -61,7 +58,7 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="RealFuels.csproj">
-      <Project>{0041813d-dcd1-4ac7-8327-85765bf924a3}</Project>
+      <Project>{0041813D-DCD1-4AC7-8327-85765BF924A3}</Project>
       <Name>RealFuels</Name>
       <Private>False</Private>
     </ProjectReference>

--- a/Source/TweakScale_RealFuels.csproj
+++ b/Source/TweakScale_RealFuels.csproj
@@ -39,12 +39,7 @@
   </ItemGroup>
   <ItemGroup>
     <Reference Include="Assembly-CSharp">
-      <HintPath>..\..\..\..\..\..\Games\KSP_090clean\KSP_Data\Managed\Assembly-CSharp.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="Scale_Redist">
-      <HintPath>..\RealFuels\Plugins\Scale_Redist.dll</HintPath>
-      <Private>False</Private>
+      <HintPath>..\..\..\..\..\..\Games\KSP_win_1.0.4_STOCK\KSP_Data\Managed\Assembly-CSharp.dll</HintPath>
     </Reference>
     <Reference Include="SolverEngines">
       <HintPath>..\..\SolverEngines\GameData\SolverEngines\Plugins\SolverEngines.dll</HintPath>
@@ -52,8 +47,7 @@
     </Reference>
     <Reference Include="System" />
     <Reference Include="UnityEngine">
-      <HintPath>..\..\..\..\..\..\Games\KSP_090clean\KSP_Data\Managed\UnityEngine.dll</HintPath>
-      <Private>False</Private>
+      <HintPath>..\..\..\..\..\..\Games\KSP_win_1.0.4_STOCK\KSP_Data\Managed\UnityEngine.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/Source/assembly/Checkers.cs
+++ b/Source/assembly/Checkers.cs
@@ -198,7 +198,6 @@ namespace RealFuels
 
         public static bool IsAllCompatible()
         {
-			return true;
             return IsCompatible() && IsUnityCompatible() && !IsWin64();
         }
 

--- a/Source/assembly/Checkers.cs
+++ b/Source/assembly/Checkers.cs
@@ -198,6 +198,7 @@ namespace RealFuels
 
         public static bool IsAllCompatible()
         {
+			return true;
             return IsCompatible() && IsUnityCompatible() && !IsWin64();
         }
 

--- a/Source/modularFuelTanks.userprefs
+++ b/Source/modularFuelTanks.userprefs
@@ -1,0 +1,8 @@
+﻿<Properties StartupItem="modularFuelTanks.csproj">
+  <MonoDevelop.Ide.Workspace ActiveConfiguration="Release" />
+  <MonoDevelop.Ide.Workbench />
+  <MonoDevelop.Ide.DebuggingService.Breakpoints>
+    <BreakpointStore />
+  </MonoDevelop.Ide.DebuggingService.Breakpoints>
+  <MonoDevelop.Ide.DebuggingService.PinnedWatches />
+</Properties>


### PR DESCRIPTION
* Reworking of cryogenic boiloff.
* Features: code has been brought up to date with KSP 1.0 thermodynamics. tank.loss_rate is respected as backup if no resource.vsp is found (heat of vaporization)
* When vsp is found, heat leakage into tank is calculated using temperature delta between part.temperature and tank.temperature (the listed point of boiloff)
* TANK configs accept wallThickness, wallConductivity, insulationThickness and insulationConductivity. The conductivity values are found for a material in real life. Tanks are set to 205 (aluminum varies across a wide range depending on temperature).
* Tank thickness is 0.1 by default but that's probably too high and needs revisiting. (0.01 - 0.03?)
* TANK_DEFINITION can accept outerInsulationFactor and this corresponds to part.heatConductivity & part.skinInternalConductionMult. (result is that part-part heat conduction is scaled by 0.01 and skin-internal by 0.001)
* Boiloff code executes AFTER all other FixedUpdate methods have finished. This gives parts like radiators time to try to remove excess heat. (uses CoRoutine & WaitForFixedUpdate)