### PR TITLE
Last 1.0.4 update

### DIFF
--- a/RealFuels/Resources/RealTankTypes.cfg
+++ b/RealFuels/Resources/RealTankTypes.cfg
@@ -503,6 +503,8 @@ TANK_DEFINITION
 		fillable = True
 		amount = 0.0
 		maxAmount = 0.0
+		wallThickness = 0.0025
+		wallConduction = 16
 		temperature = 90.15		
 		note = (has insulation)
 	}
@@ -1001,7 +1003,7 @@ TANK_DEFINITION
 		maxAmount = 0.0
 		temperature = 90.15
 		wallThickness = 0.0025
-		wallConduction = 205
+		wallConduction = 16
 		insulationThickness = 0.038181
 		insulationConduction = 0.0001
 		note = (has insulation, pressurized)
@@ -1724,6 +1726,8 @@ TANK_DEFINITION
 		fillable = True
 		amount = 0.0
 		maxAmount = 0.0
+		wallThickness = 0.0025
+		wallConduction = 16
 		temperature = 90.15
 		loss_rate = 0.000000005
 		note = (lacks insulation)
@@ -2938,6 +2942,8 @@ TANK_DEFINITION
 		fillable = True
 		amount = 0.0
 		maxAmount = 0.0
+		wallThickness = 0.0025
+		wallConduction = 16
 		temperature = 90.15
 		loss_rate = 0.000000005
 		note = (lacks insulation)
@@ -3430,7 +3436,7 @@ TANK_DEFINITION
 		maxAmount = 0.0
 		temperature = 90.15
 		wallThickness = 0.0025
-		wallConduction = 205
+		wallConduction = 16
 		insulationThickness = 0.0381
 		insulationConduction = 0.014
 		note = (has insulation)

--- a/RealFuels/Resources/RealTankTypes.cfg
+++ b/RealFuels/Resources/RealTankTypes.cfg
@@ -494,7 +494,7 @@ TANK_DEFINITION
 	name = Cryogenic
 	highlyPressurized = False
 	basemass = 0.000019 * volume
-	outerInsulationFactor = 0.01
+	outerInsulationFactor = 0.0005
 	TANK
 	{
 		name = LqdOxygen
@@ -3425,7 +3425,7 @@ TANK_DEFINITION
 	name = BalloonCryo
 	highlyPressurized = False
 	basemass = 0.000005 * volume
-	outerInsulationFactor = 0.01
+	outerInsulationFactor = 0.0005
 	TANK
 	{
 		name = LqdOxygen

--- a/RealFuels/Resources/RealTankTypes.cfg
+++ b/RealFuels/Resources/RealTankTypes.cfg
@@ -12,6 +12,8 @@ TANK_DEFINITION
 		fillable = True
 		amount = 0.0
 		maxAmount = 0.0
+		wallThickness = 0.0025
+		wallConduction = 16
 		temperature = 90.15
 		note = (lacks insulation)
 	}

--- a/Source/RealFuels.csproj
+++ b/Source/RealFuels.csproj
@@ -3,13 +3,17 @@
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProductVersion>10.0.0</ProductVersion>
+    <SchemaVersion>2.0</SchemaVersion>
     <ProjectGuid>{0041813D-DCD1-4AC7-8327-85765BF924A3}</ProjectGuid>
     <OutputType>Library</OutputType>
     <RootNamespace>RealFuels</RootNamespace>
     <AssemblyName>RealFuels</AssemblyName>
     <TargetFrameworkVersion>v3.5</TargetFrameworkVersion>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>false</DebugSymbols>
     <DebugType>none</DebugType>
     <Optimize>False</Optimize>
     <BaseIntermediateOutputPath>..\..\Build\RealFuels\obj\</BaseIntermediateOutputPath>
@@ -18,11 +22,6 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <ConsolePause>False</ConsolePause>
-    <CustomCommands>
-      <CustomCommands>
-        <Command type="AfterBuild" command="xcopy /y C:\Users\Kevin\Documents\GitHub\ModularFuelSystem\RealFuels\Plugins\RealFuels.dll C:\Games\KSP_win_1.0.4_STOCK\GameData\RealFuels\Plugins\" externalConsole="True" />
-      </CustomCommands>
-    </CustomCommands>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>none</DebugType>
@@ -32,25 +31,26 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <ConsolePause>False</ConsolePause>
-    <CustomCommands>
-      <CustomCommands>
-        <Command type="AfterBuild" command="xcopy /y C:\Users\Kevin\Documents\GitHub\ModularFuelSystem\RealFuels\Plugins\RealFuels.dll C:\Games\KSP_win_1.0.4_STOCK\GameData\RealFuels\Plugins\" externalConsole="True" />
-      </CustomCommands>
-    </CustomCommands>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Assembly-CSharp">
+    <Reference Include="Assembly-CSharp, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\..\..\..\..\Games\KSP_win_1.0.4_STOCK\KSP_Data\Managed\Assembly-CSharp.dll</HintPath>
     </Reference>
-    <Reference Include="UnityEngine">
+    <Reference Include="KSPAPIExtensions, Version=1.7.5.0, Culture=neutral, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\..\..\..\..\Games\KSP_win_1.0.4_STOCK\GameData\ProceduralFairings\KSPAPIExtensions.dll</HintPath>
+    </Reference>
+    <Reference Include="SolverEngines, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\..\..\..\..\Games\KSP_win_1.0.4_STOCK\GameData\SolverEngines\Plugins\SolverEngines.dll</HintPath>
+    </Reference>
+    <Reference Include="System, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+    </Reference>
+    <Reference Include="UnityEngine, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\..\..\..\..\Games\KSP_win_1.0.4_STOCK\KSP_Data\Managed\UnityEngine.dll</HintPath>
-    </Reference>
-    <Reference Include="System" />
-    <Reference Include="KSPAPIExtensions">
-      <HintPath>..\..\..\..\..\..\Games\KSP_win_1.0.4\GameData\RealFuels\Plugins\KSPAPIExtensions.dll</HintPath>
-    </Reference>
-    <Reference Include="SolverEngines">
-      <HintPath>..\..\..\..\..\..\Games\KSP_win_1.0.4\GameData\SolverEngines\Plugins\SolverEngines.dll</HintPath>
     </Reference>
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
@@ -83,8 +83,7 @@
   </ItemGroup>
   <ItemGroup />
   <PropertyGroup>
-    <PreBuildEvent>cd $(ProjectDir)
-
-<!-- sh tools/git-version.sh --></PreBuildEvent>
+    <PreBuildEvent>
+    </PreBuildEvent>
   </PropertyGroup>
 </Project>

--- a/Source/RealFuels.sln
+++ b/Source/RealFuels.sln
@@ -1,6 +1,8 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 2012
+# Visual Studio 14
+VisualStudioVersion = 14.0.23107.0
+MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "RealFuels", "RealFuels.csproj", "{0041813D-DCD1-4AC7-8327-85765BF924A3}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TweakScale_RealFuels", "TweakScale_RealFuels.csproj", "{F2B85F9A-6E39-4525-B31F-A3D764DE28D0}"
@@ -20,41 +22,10 @@ Global
 		{F2B85F9A-6E39-4525-B31F-A3D764DE28D0}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{F2B85F9A-6E39-4525-B31F-A3D764DE28D0}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
-	GlobalSection(MonoDevelopProperties) = preSolution
-		StartupItem = RealFuels.csproj
-		Policies = $0
-		$0.DotNetNamingPolicy = $1
-		$1.DirectoryNamespaceAssociation = None
-		$1.ResourceNamePolicy = FileFormatDefault
-		$0.TextStylePolicy = $2
-		$2.inheritsSet = VisualStudio
-		$2.inheritsScope = text/plain
-		$2.scope = text/x-csharp
-		$0.CSharpFormattingPolicy = $3
-		$3.IndentSwitchBody = True
-		$3.AnonymousMethodBraceStyle = NextLine
-		$3.PropertyBraceStyle = NextLine
-		$3.PropertyGetBraceStyle = NextLine
-		$3.PropertySetBraceStyle = NextLine
-		$3.EventBraceStyle = NextLine
-		$3.EventAddBraceStyle = NextLine
-		$3.EventRemoveBraceStyle = NextLine
-		$3.StatementBraceStyle = NextLine
-		$3.ArrayInitializerBraceStyle = NextLine
-		$3.BeforeMethodDeclarationParentheses = False
-		$3.BeforeMethodCallParentheses = False
-		$3.BeforeConstructorDeclarationParentheses = False
-		$3.BeforeDelegateDeclarationParentheses = False
-		$3.NewParentheses = False
-		$3.inheritsSet = Mono
-		$3.inheritsScope = text/x-csharp
-		$3.scope = text/x-csharp
-		$0.TextStylePolicy = $4
-		$4.inheritsSet = VisualStudio
-		$4.inheritsScope = text/plain
-		$4.scope = text/plain
-	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(MonoDevelopProperties) = preSolution
+		StartupItem = modularFuelTanks.csproj
 	EndGlobalSection
 EndGlobal

--- a/Source/RealFuels.userprefs
+++ b/Source/RealFuels.userprefs
@@ -1,10 +1,18 @@
 ﻿<Properties StartupItem="RealFuels.csproj">
-  <MonoDevelop.Ide.Workspace ActiveConfiguration="Debug" />
-  <MonoDevelop.Ide.Workbench ActiveDocument="Tanks\ModuleFuelTanks.cs">
+  <MonoDevelop.Ide.Workspace ActiveConfiguration="Release" />
+  <MonoDevelop.Ide.Workbench ActiveDocument="..\..\..\..\..\..\Windows\Microsoft.NET\Framework\v4.0.30319\Microsoft.Common.targets">
     <Files>
-      <File FileName="Tanks\ModuleFuelTanks.cs" Line="395" Column="77" />
+      <File FileName="Tanks\ModuleFuelTanks.cs" Line="1" Column="1" />
+      <File FileName="Tanks\FuelTank.cs" Line="1" Column="1" />
+      <File FileName="Tanks\TankDefinition.cs" Line="1" Column="1" />
       <File FileName="Engines\ModuleEngineConfigs.cs" Line="1" Column="1" />
+      <File FileName="Engines\SolverRF.cs" Line="1" Column="1" />
+      <File FileName="Engines\ModuleEnginesRF.cs" Line="1" Column="1" />
       <File FileName="c:\Users\Kevin\Documents\GitHub\ModularFuelSystem\Source\Engines\EngineConfigUpgrade.cs" Line="1" Column="1" />
+      <File FileName="assembly\AssemblyInfoRF.cs" Line="1" Column="1" />
+      <File FileName="assembly\VersionReport.cs" Line="1" Column="1" />
+      <File FileName="assembly\Checkers.cs" Line="1" Column="1" />
+      <File FileName="..\..\..\..\..\..\Windows\Microsoft.NET\Framework\v4.0.30319\Microsoft.Common.targets" Line="1605" Column="5" />
     </Files>
   </MonoDevelop.Ide.Workbench>
   <MonoDevelop.Ide.DebuggingService.Breakpoints>

--- a/Source/Tanks/MFSSettings.cs
+++ b/Source/Tanks/MFSSettings.cs
@@ -16,8 +16,9 @@ namespace RealFuels
         public static float partUtilizationDefault = 86;
         public static bool partUtilizationTweakable = false;
         public static string unitLabel = "u";
-
         public static bool basemassUseTotalVolume = false;
+        public static bool ferociousBoilOff = true;
+        public static bool globalConductionCompensation = false;
 
         public static HashSet<string> ignoreFuelsForFill;
         public static Tanks.TankDefinitionList tankDefinitions;
@@ -125,14 +126,22 @@ namespace RealFuels
 				if (bool.TryParse (node.GetValue ("partUtilizationTweakable"), out tb)) {
 					partUtilizationTweakable = tb;
 				}
-				if (node.HasValue ("unitLabel")) {
+                if (node.HasValue ("unitLabel")) {
 					unitLabel = node.GetValue ("unitLabel");
 				}
                 if (bool.TryParse(node.GetValue("basemassUseTotalVolume"), out tb)) {
                     basemassUseTotalVolume = tb;
                 }
+                if (bool.TryParse(node.GetValue("ferociousBoilOff"), out tb))
+                {
+                    ferociousBoilOff = tb;
+                }
+                if (bool.TryParse(node.GetValue("globalConductionCompensation"), out tb))
+                {
+                    globalConductionCompensation = tb;
+                }
 
-				ConfigNode ignoreNode = node.GetNode ("IgnoreFuelsForFill");
+                ConfigNode ignoreNode = node.GetNode ("IgnoreFuelsForFill");
 				if (ignoreNode != null) {
 					foreach (ConfigNode.Value v in ignoreNode.values) {
 						ignoreFuelsForFill.Add (v.name);

--- a/Source/Tanks/ModuleFuelTanks.cs
+++ b/Source/Tanks/ModuleFuelTanks.cs
@@ -399,7 +399,7 @@ namespace RealFuels.Tanks
 #if DEBUG
                                 // Only do debugging displays if compiled for debugging.
                                 debug1Display += FormatFlux(q);
-                                debug2Display += (massLost * 1000 * 3600).ToString("F4") + "/hr";
+                                debug2Display += (massLost * 1000 * 3600).ToString("F4") + "kg/hr";
                                 //debug2Display += area.ToString("F2");
 
                                 //debug1Display = tank.wallThickness + " / " + tank.wallConduction;

--- a/Source/TechLevels/TechLevel.cs
+++ b/Source/TechLevels/TechLevel.cs
@@ -409,7 +409,14 @@ namespace RealFuels.TechLevels
             TechLevel nTL = new TechLevel();
             if (!nTL.Load(cfg, mod, type, level))
                 return false;
-            return HighLogic.CurrentGame.Mode == Game.Modes.SANDBOX || nTL.techRequired.Equals("") || ResearchAndDevelopment.GetTechnologyState(nTL.techRequired) == RDTech.State.Available;
+            try
+            {
+                return HighLogic.CurrentGame.Mode == Game.Modes.SANDBOX || nTL.techRequired.Equals("") || ResearchAndDevelopment.GetTechnologyState(nTL.techRequired) == RDTech.State.Available;
+            }
+            catch (Exception)
+            {
+                return false;
+            }
         }
     }
 }

--- a/Source/TweakScale_RealFuels.csproj
+++ b/Source/TweakScale_RealFuels.csproj
@@ -3,13 +3,12 @@
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProductVersion>10.0.0</ProductVersion>
-    <SchemaVersion>2.0</SchemaVersion>
     <ProjectGuid>{F2B85F9A-6E39-4525-B31F-A3D764DE28D0}</ProjectGuid>
     <OutputType>Library</OutputType>
     <RootNamespace>RealFuels</RootNamespace>
     <AssemblyName>TweakScale_RealFuels</AssemblyName>
     <TargetFrameworkVersion>v3.5</TargetFrameworkVersion>
+    <ReleaseVersion>10.7.1</ReleaseVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>True</DebugSymbols>
@@ -41,9 +40,16 @@
     <Reference Include="Assembly-CSharp">
       <HintPath>..\..\..\..\..\..\Games\KSP_win_1.0.4_STOCK\KSP_Data\Managed\Assembly-CSharp.dll</HintPath>
     </Reference>
-    <Reference Include="SolverEngines">
-      <HintPath>..\..\SolverEngines\GameData\SolverEngines\Plugins\SolverEngines.dll</HintPath>
-      <Private>False</Private>
+    <Reference Include="Scale">
+      <HintPath>..\..\TweakScale\GameData\TweakScale\plugins\Scale.dll</HintPath>
+    </Reference>
+    <Reference Include="Scale_Redist, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\TweakScale\GameData\TweakScale\plugins\Scale_Redist.dll</HintPath>
+    </Reference>
+    <Reference Include="SolverEngines, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\..\..\..\..\Games\KSP_win_1.0.4_STOCK\GameData\SolverEngines\Plugins\SolverEngines.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="UnityEngine">


### PR DESCRIPTION
* Increased boiloff rate can be switched off by adding ferociousBoilOff
= False to MFSSETTINGS (best use MM patch for that)
* PhysicsGlobal.conductionFactor can be compensated for by adding 
globalConductionCompensation  = true to MFSSETTINGS (not recommended but 
made available)
* cryogenic outerInsulation improved to 0.0005 (previous value 0.01)
* All LOX tanks now assume stainless steel tanks, except the ServiceModule.