### PR TITLE
KSP 1.1 Fixes - Mostly GUI

### DIFF
--- a/Source/Engines/ModuleEngineConfigs.cs
+++ b/Source/Engines/ModuleEngineConfigs.cs
@@ -3,10 +3,8 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Reflection;
 using System.Linq;
-using KSPAPIExtensions.PartMessage;
 using UnityEngine;
 using KSP;
-using KSPAPIExtensions.Utils;
 using Debug = UnityEngine.Debug;
 using RealFuels.TechLevels;
 using SolverEngines;
@@ -214,7 +212,6 @@ namespace RealFuels
                 compatible = false;
                 return;
             }
-            PartMessageService.Register(this);
             if (HighLogic.LoadedSceneIsEditor)
             {
                 GameEvents.onPartActionUIDismiss.Add(OnPartActionGuiDismiss);

--- a/Source/Engines/ModuleEngineConfigs.cs
+++ b/Source/Engines/ModuleEngineConfigs.cs
@@ -1242,7 +1242,8 @@ namespace RealFuels
                 if (cursorInGUI)
                 {
                     editor.Lock(false, false, false, "RFGUILock");
-                    EditorTooltip.Instance.HideToolTip();
+                    if (EditorTooltip.Instance != null)
+                        EditorTooltip.Instance.HideToolTip();
                 }
                 else
                 {
@@ -1260,7 +1261,8 @@ namespace RealFuels
                 if (cursorInGUI)
                 {
                     editor.Lock(false, false, false, "RFGUILock");
-                    EditorTooltip.Instance.HideToolTip();
+                    if (EditorTooltip.Instance != null)
+                        EditorTooltip.Instance.HideToolTip();
                 }
                 else
                 {

--- a/Source/Engines/ModuleEnginesRF.cs
+++ b/Source/Engines/ModuleEnginesRF.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
-
 using UnityEngine;
 using KSP;
 using SolverEngines;

--- a/Source/Engines/RFSettings.cs
+++ b/Source/Engines/RFSettings.cs
@@ -3,7 +3,6 @@ using System.Collections.ObjectModel;
 using System.Reflection;
 using System.Linq;
 using UnityEngine;
-using KSPAPIExtensions;
 
 namespace RealFuels
 {
@@ -98,8 +97,8 @@ namespace RealFuels
             }
 
             var asm = Assembly.GetCallingAssembly ();
-            var title = SystemUtils.GetAssemblyTitle (asm);
-            version = title + " " + SystemUtils.GetAssemblyVersionString (asm);
+            var title = MFSVersionReport.GetAssemblyTitle (asm);
+            version = title + " " + MFSVersionReport.GetAssemblyVersionString (asm);
 
             return version;
         }

--- a/Source/Engines/UpgradeManager.cs
+++ b/Source/Engines/UpgradeManager.cs
@@ -3,7 +3,6 @@ using System.Collections.ObjectModel;
 using System.Reflection;
 using System.Linq;
 using UnityEngine;
-using KSPAPIExtensions;
 
 namespace RealFuels
 {

--- a/Source/Tanks/TankWindow.cs
+++ b/Source/Tanks/TankWindow.cs
@@ -141,11 +141,11 @@ namespace RealFuels.Tanks
 			cursorInGUI = guiWindowRect.Contains (mousePos);
 			if (cursorInGUI) {
 				editor.Lock (false, false, false, "MFTGUILock");
-				EditorTooltip.Instance.HideToolTip ();
+                if (EditorTooltip.Instance != null)
+				    EditorTooltip.Instance.HideToolTip ();
 			} else {
 				editor.Unlock ("MFTGUILock");
 			}
-
             GUI.Label (tooltipRect, myToolTip);
             guiWindowRect = GUILayout.Window (GetInstanceID (), guiWindowRect, GUIWindow, "Fuel Tanks for " + tank_module.part.partInfo.title);
         }


### PR DESCRIPTION
**This is for KSP 1.1**

Fixed issues in the GUI that were causing crashes.  RF and MFT appear to be working fine for me in 1. now, though I have not done any **extensive** testing.  What I did do was verify proper operation on the VAB, then launch a rocket.  I launched a rocket both with and without tanks filled to ensure that worked as expected.

Note that due to IDE differences, and managed path differences, this PR is a code change only.  References will need to be updated by the project maintainers.  Looks like the only change I made to references was to remove KSPAPIExtensions