### PR TITLE
Added GUI Styles and updated Engine and Tank editor GUIs

### DIFF
--- a/Source/Engines/ModuleEngineConfigs.cs
+++ b/Source/Engines/ModuleEngineConfigs.cs
@@ -1206,8 +1206,15 @@ namespace RealFuels
         private Rect guiWindowRect = new Rect(0, 0, 0, 0);
         public static string myToolTip = "";
         private int counterTT;
+        private bool styleSetup = false;
         public void OnGUI()
         {
+            if (!styleSetup)
+            {
+                styleSetup = true;
+                Styles.InitStyles ();
+            }
+
             if (!compatible)
                 return;
 
@@ -1270,10 +1277,11 @@ namespace RealFuels
                 editor.Unlock("RFGUILock");
                 return;
             }
+            myToolTip = myToolTip.Trim ();
+            if (!String.IsNullOrEmpty(myToolTip))
+                GUI.Label(tooltipRect, myToolTip, Styles.styleEditorTooltip);
 
-            GUI.Label(tooltipRect, myToolTip);
-
-            guiWindowRect = GUILayout.Window(part.name.GetHashCode() + 1, guiWindowRect, engineManagerGUI, "Configure " + part.partInfo.title);
+            guiWindowRect = GUILayout.Window(part.name.GetHashCode() + 1, guiWindowRect, engineManagerGUI, "Configure " + part.partInfo.title, Styles.styleEditorPanel);
         }
 
         /*private int oldTechLevel = -1;
@@ -1314,6 +1322,7 @@ namespace RealFuels
 
         private void engineManagerGUI(int WindowID)
         {
+            GUILayout.Space (20);
             foreach (ConfigNode node in configs)
             {
                 string nName = node.GetValue("name");

--- a/Source/RealFuels.csproj
+++ b/Source/RealFuels.csproj
@@ -73,6 +73,7 @@
     <Compile Include="Ullage\UllageSimulator.cs" />
     <Compile Include="Utilities\ConfigNodeExtensions.cs" />
     <Compile Include="Utilities\Utilities.cs" />
+    <Compile Include="Utilities\Styles.cs" />
   </ItemGroup>
   <ItemGroup />
   <PropertyGroup>

--- a/Source/Tanks/TankWindow.cs
+++ b/Source/Tanks/TankWindow.cs
@@ -107,8 +107,15 @@ namespace RealFuels.Tanks
 
         private Rect guiWindowRect = new Rect (0, 0, 0, 0);
         private static Vector3 mousePos = Vector3.zero;
+        private bool styleSetup = false;
         public void OnGUI ()
         {
+            if (!styleSetup)
+            {
+                styleSetup = true;
+                Styles.InitStyles ();
+            }
+
             EditorLogic editor = EditorLogic.fetch;
             if (!HighLogic.LoadedSceneIsEditor || !editor) {
                 return;
@@ -143,8 +150,10 @@ namespace RealFuels.Tanks
 			} else {
 				editor.Unlock ("MFTGUILock");
 			}
-            GUI.Label (tooltipRect, myToolTip);
-            guiWindowRect = GUILayout.Window (GetInstanceID (), guiWindowRect, GUIWindow, "Fuel Tanks for " + tank_module.part.partInfo.title);
+            myToolTip = myToolTip.Trim ();
+            if (!String.IsNullOrEmpty(myToolTip))
+                GUI.Label(tooltipRect, myToolTip, Styles.styleEditorTooltip);
+            guiWindowRect = GUILayout.Window (GetInstanceID (), guiWindowRect, GUIWindow, "Fuel Tanks for " + tank_module.part.partInfo.title, Styles.styleEditorPanel);
         }
 
 		void DisplayMass ()
@@ -170,6 +179,7 @@ namespace RealFuels.Tanks
 			InitializeStyles ();
 
 			GUILayout.BeginVertical ();
+            GUILayout.Space (20);
 
 			if (CheckTankList ()) {
 				GUILayout.BeginHorizontal ();

--- a/Source/Utilities/Styles.cs
+++ b/Source/Utilities/Styles.cs
@@ -1,0 +1,58 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+using System.IO;
+
+using KSP;
+using UnityEngine;
+
+namespace RealFuels
+{
+    internal class Styles
+    {
+        // Base styles
+        public static GUIStyle styleEditorTooltip;
+        public static GUIStyle styleEditorPanel;
+
+
+        /// <summary>
+        /// This one sets up the styles we use
+        /// </summary>
+        internal static void InitStyles()
+        {
+            styleEditorTooltip = new GUIStyle();
+            styleEditorTooltip.name = "Tooltip";
+            styleEditorTooltip.fontSize = 12;
+            styleEditorTooltip.normal.textColor = new Color32(207,207,207,255);
+            styleEditorTooltip.stretchHeight = true;
+            styleEditorTooltip.wordWrap = true;
+            styleEditorTooltip.normal.background = CreateColorPixel(new Color32(7,54,66,200));
+            styleEditorTooltip.border = new RectOffset(3, 3, 3, 3);
+            styleEditorTooltip.padding = new RectOffset(4, 4, 6, 4);
+            styleEditorTooltip.alignment = TextAnchor.MiddleLeft;
+
+            styleEditorPanel = new GUIStyle();
+            styleEditorPanel.normal.background = CreateColorPixel(new Color32(7,54,66,200));
+            styleEditorPanel.border = new RectOffset(27, 27, 27, 27);
+            styleEditorPanel.padding = new RectOffset(10, 10, 10, 10);
+            styleEditorPanel.normal.textColor = new Color32(147,161,161,255);
+            styleEditorPanel.fontSize = 12;
+        }
+
+
+        /// <summary>
+        /// Creates a 1x1 texture
+        /// </summary>
+        /// <param name="Background">Color of the texture</param>
+        /// <returns></returns>
+        internal static Texture2D CreateColorPixel(Color32 Background)
+        {
+            Texture2D retTex = new Texture2D(1, 1);
+            retTex.SetPixel(0, 0, Background);
+            retTex.Apply();
+            return retTex;
+        }
+    }
+}


### PR DESCRIPTION
Added a couple GUI styles based on TestFlight's style.  Setup the Tank and Engine GUIs to use these for panels and tooltips.

This makes the windows and more importantly the Tooltips about a billion times easier to actually read.