### PR TITLE
Surface Area changes

### DIFF
--- a/Source/Engines/RFSettings.cs
+++ b/Source/Engines/RFSettings.cs
@@ -34,6 +34,10 @@ namespace RealFuels
         public double throttlingRate = 10d;
         public double throttlingClamp = 1.1d;
 
+        public static bool ferociousBoilOff = true;
+        public static bool globalConductionCompensation = false;
+        public static bool debugBoilOff = false;
+
         #region Ullage
         public bool simulateUllage = true;
         public bool limitedIgnitions = true;
@@ -140,6 +144,9 @@ namespace RealFuels
             node.TryGetValue("techLevelScienceEntryCostFraction", ref techLevelScienceEntryCostFraction);
             node.TryGetValue("configCostToScienceMultiplier", ref configCostToScienceMultiplier);
             node.TryGetValue("usePartNameInConfigUnlock", ref usePartNameInConfigUnlock);
+            node.TryGetValue("ferociousBoilOff", ref ferociousBoilOff);
+            node.TryGetValue("globalConductionCompensation", ref globalConductionCompensation);
+            node.TryGetValue("debugBoilOff", ref debugBoilOff);
 
             #region Ullage
             if (node.HasNode("Ullage"))

--- a/Source/Tanks/FuelTank.cs
+++ b/Source/Tanks/FuelTank.cs
@@ -40,6 +40,9 @@ namespace RealFuels.Tanks
 		public double loss_rate = 0.0;
         // representing conduction factor from Fourier conduction formula.
         public double vsp;
+        // cache for tank.totalArea and tank.tankRatio for use by ModuleFuelTanks
+        public double totalArea = -1;
+        public double tankRatio = -1;
 
         //[Persistent]
         public double wallThickness = 0.1;

--- a/Source/Tanks/MFSSettings.cs
+++ b/Source/Tanks/MFSSettings.cs
@@ -16,8 +16,6 @@ namespace RealFuels
         public static bool partUtilizationTweakable = false;
         public static string unitLabel = "u";
         public static bool basemassUseTotalVolume = false;
-        public static bool ferociousBoilOff = true;
-        public static bool globalConductionCompensation = false;
         public static double radiatorMinTempMult = 0.99d;
 
         public static HashSet<string> ignoreFuelsForFill;
@@ -132,14 +130,6 @@ namespace RealFuels
 				}
                 if (bool.TryParse(node.GetValue("basemassUseTotalVolume"), out tb)) {
                     basemassUseTotalVolume = tb;
-                }
-                if (bool.TryParse(node.GetValue("ferociousBoilOff"), out tb))
-                {
-                    ferociousBoilOff = tb;
-                }
-                if (bool.TryParse(node.GetValue("globalConductionCompensation"), out tb))
-                {
-                    globalConductionCompensation = tb;
                 }
                 if (node.HasValue("radiatorMinTempMult"))
                     if (double.TryParse(node.GetValue("radiatorMinTempMult"), out td))


### PR DESCRIPTION
* Moved some settings from MFSSETTINGS. (were meant to be in RFSETTINGS
and weren't being set)
* Added tank area cache fields to FuelTank so we're not recalculating
these every frame when they never change.
* Changed debug fields to use RFSETTINGS.debugBoiloff so I don't have to
compile a debug plugin just to watch boiloff. (and so players can use
this too)
* Changes to individual tank surface area calculation: Assume a sphere
if tankRatio <= 0.125 (maybe increase this to 0.25 - 0.5) (this can
still be improved further, previous method was overly simplistic and 
fails for very small tanks)