### PR TITLE
Added boiloff product and resource conductivity

### DIFF
--- a/RealFuels/Resources/ResourceHsps.cfg
+++ b/RealFuels/Resources/ResourceHsps.cfg
@@ -2,11 +2,13 @@
 {
 	%hsp = 918 // specific heat capacity (kJ/tonne-K as units) // recalc, mols are for O2 on wiki
 	%vsp = 213000 // heat of vapourization (KJ/tonne as units)
+	%conductivity = 0.152
 }
 @RESOURCE_DEFINITION[LqdHydrogen]:FOR[RealFuels]
 {
 	%hsp = 14305 // specific heat capacity (kJ/tonne-K as units) // recalc, mols are for H2 on wiki
 	%vsp = 448500 // heat of vapourization (KJ/tonne as units)  or 8.97 * 10^5 or 8.97E5?
+	%conductivity = 0.072
 }
 @RESOURCE_DEFINITION[Kerosene]:FOR[RealFuels]
 {
@@ -97,7 +99,19 @@
 {
 	%hsp = 920 // FIXME, total guess but based on 'standardized' solids and the stock SolidFuel %hsp.
 }
-@RESOURCE_DEFINITION[LqdAmmonia]
+@RESOURCE_DEFINITION[LqdAmmonia]:FOR[RealFuels]
 {
 	%vsp = 1373000 // http://www.engineeringtoolbox.com/ammonia-d_1413.html
+}
+@RESOURCE_DEFINITION[LqdNitrogen]:FOR[RealFuels] // TODO: add vsp later
+{
+	%conductivity = 0.14
+}
+@RESOURCE_DEFINITION[LqdHelium]:FOR[RealFuels] // TODO: add vsp later
+{
+	%conductivity = 0.019
+}
+@RESOURCE_DEFINITION[LqdMethane]:FOR[RealFuels]
+{
+	%conductivity = 0.18455
 }

--- a/Source/Tanks/MFSSettings.cs
+++ b/Source/Tanks/MFSSettings.cs
@@ -23,6 +23,7 @@ namespace RealFuels
 
 		public static Dictionary<string, HashSet<string>> managedResources;
         public static Dictionary<string, double> resourceVsps;
+        public static Dictionary<string, double> resourceConductivities;
 
         private static Dictionary<string, ConfigNode[]> overrides;
 
@@ -90,8 +91,9 @@ namespace RealFuels
 			managedResources = new Dictionary<string,HashSet<string>> ();
             overrides = new Dictionary<string, ConfigNode[]>();
 
-            // fill vsps
+            // fill vsps & conductivities
             resourceVsps = new Dictionary<string, double>();
+            resourceConductivities = new Dictionary<string, double>();
             foreach (ConfigNode n in GameDatabase.Instance.GetConfigNodes("RESOURCE_DEFINITION"))
             {
                 if (n.HasValue("vsp"))
@@ -100,7 +102,14 @@ namespace RealFuels
                     if (double.TryParse(n.GetValue("vsp"), out dtmp))
                         resourceVsps[n.GetValue("name")] = dtmp;
                 }
+                if (n.HasValue("conductivity"))
+                {
+                    double dtmp;
+                    if (double.TryParse(n.GetValue("conductivity"), out dtmp))
+                        resourceConductivities[n.GetValue("name")] = dtmp;
+                }
             }
+
 
             ConfigNode node = GameDatabase.Instance.GetConfigNodes ("MFSSETTINGS").LastOrDefault ();
             Debug.Log ("[MFS] Loading global settings");


### PR DESCRIPTION
* Added support for boiloff product:  Tanks can be now be configured to produce a resource as their contents boiloff. (i.e. gaseous hydrogen from liquid hydrogen). Requires a tank capable of receiving the resource.
* Factored in resource conductivity to heat leakage calculation. (impact on boiloff rates is marginal at best)
* Changed new surface area code to just use the greater of two calculations: The older simplified code and spherical tank code. By volume, nothing should have lower surface area than a sphere so if it's lower then go with sphere.
* Added conductivity values to several cryo resources.
* Added :FOR[RealFuels] to several of them in keeping with other RF resource config patches.