### PR TITLE
Always allow ignition while attached to launch clamps

### DIFF
--- a/Source/Engines/ModuleEngineConfigs.cs
+++ b/Source/Engines/ModuleEngineConfigs.cs
@@ -142,6 +142,9 @@ namespace RealFuels
         [KSPField(isPersistant = true)]
         public bool modded = false;
 
+        [KSPField]
+        public bool literalZeroIgnitions = false; /* Normally, ignitions = 0 means unlimited.  Setting this changes it to really mean zero */
+
         public List<ConfigNode> configs;
         public ConfigNode config;
 
@@ -496,6 +499,8 @@ namespace RealFuels
                             info += ", ";
                         if (ignitions > 0)
                             info += ignitions + " ignition" + (ignitions > 1 ? "s" : "");
+                        else if (literalZeroIgnitions && ignitions == 0)
+                            info += "ground ignition only";
                         else
                             info += "unl. ignitions";
                     }
@@ -851,7 +856,7 @@ namespace RealFuels
                 if (ignitions < 1)
                     ignitions = 1;
             }
-            else if (ignitions == 0)
+            else if (ignitions == 0 && !literalZeroIgnitions)
                 ignitions = -1;
             return ignitions;
         }

--- a/Source/Engines/ModuleEnginesRF.cs
+++ b/Source/Engines/ModuleEnginesRF.cs
@@ -618,7 +618,7 @@ namespace RealFuels
             if (pressureFed)
                 output += "Pressure-fed";
             if (ignitions >= 0 && RFSettings.Instance.limitedIgnitions)
-                output += (output != "" ? ", " : "") + "Ignitions: " + ignitions;
+                output += (output != "" ? ", " : "") + "Ignitions: " + (ignitions > 0 ? ignitions.ToString() : "Ground only");
             if (!ullage)
                 output += (output != "" ? ", " : "") + "Not subject to ullage";
             if (output != "")
@@ -679,8 +679,10 @@ namespace RealFuels
             {
                 if (!ignited && reignitable)
                 {
+                    /* As long as you're on the pad, you can always ignite */
+                    bool externalIgnition = vessel.FindPartModulesImplementing<LaunchClamp>().Count > 0;
                     reignitable = false;
-                    if (ignitions == 0 && RFSettings.Instance.limitedIgnitions && !CheatOptions.InfinitePropellant)
+                    if (ignitions == 0 && RFSettings.Instance.limitedIgnitions && !CheatOptions.InfinitePropellant && !externalIgnition)
                     {
                         EngineIgnited = false; // don't play shutdown FX, just fail.
                         ScreenMessages.PostScreenMessage(igniteFailIgnitions);
@@ -716,7 +718,7 @@ namespace RealFuels
                                 }
                                 if (minResource < 1d)
                                 {
-                                    if (UnityEngine.Random.value > (float)minResource && !CheatOptions.InfinitePropellant)
+                                    if (UnityEngine.Random.value > (float)minResource && !CheatOptions.InfinitePropellant && !externalIgnition)
                                     {
                                         EngineIgnited = false; // don't play shutdown FX, just fail.
                                         ScreenMessages.PostScreenMessage(igniteFailResources);


### PR DESCRIPTION
This allows you to retry if ignition failed, as long as you're still on
the pad (and thus motivates stage-and-a-half designs like Atlas Classic,
or parallel-staged designs like the R-7).
However, ignitions (and ignitionResources) will still be consumed, so if
you have a multi-ignition first stage engine, this won't be what you
want.  I decided not to bother adding extra complications to deal with
this, as it seems a fairly uncommon case (by the time restartable first
stage engines like the Merlin are developed, ignition reliability is
basically 1).

Because one use case for this is making some engines only ignitable on
the pad (ignitions=0), have a special case for this in GetInfo output.

Also, add a flag field to ModuleEngineConfigs which, if set, specifies
that ignitions=0 actually means zero, rather than unlimited.