### PR TITLE
Fix noisy but harmless error message

### DIFF
--- a/Source/Engines/ModuleEnginesRF.cs
+++ b/Source/Engines/ModuleEnginesRF.cs
@@ -106,8 +106,6 @@ namespace RealFuels
                 atmCurve = null;
             if(!useVelCurve)
                 velCurve = null;
-            if (!useThrustCurve)
-                thrustCurve = null;
             
             // FIXME quick temp hax
             if (useAtmCurve)
@@ -162,12 +160,10 @@ namespace RealFuels
         }
         public override void OnLoad(ConfigNode node)
         {
-            if (thrustCurve == null)
-                thrustCurve = new FloatCurve();
-
             base.OnLoad(node);
+
             // Manually reload ignitions if not in editor
-            if(!HighLogic.LoadedSceneIsEditor)
+            if (!HighLogic.LoadedSceneIsEditor)
                 node.TryGetValue("ignited", ref ignited);
             int pCount = propellants.Count;
             // thrust curve


### PR DESCRIPTION
Curve was being set to null then an error message was saying that it was
null and recreating it.  It is being initialized in field initializer so
there is no need to initialize it again, just make sure it isn't set to
null.

Fixes #171