### PR TITLE
Fix for issue #180

### DIFF
--- a/Source/Engines/SolverRF.cs
+++ b/Source/Engines/SolverRF.cs
@@ -162,7 +162,8 @@ namespace RealFuels
             if (!combusting)
             {
                 double declinePow = Math.Pow(tempDeclineRate, TimeWarp.fixedDeltaTime);
-                chamberTemp = Math.Max(Math.Max(t0, partTemperature), chamberTemp * declinePow);
+                // removed t0 from next calculation; under some circumstances t0 can spike during staging/decoupling resulting in engine part destruction even on an unfired engine.
+                chamberTemp = Math.Max(partTemperature, chamberTemp * declinePow);
                 fxPower = 0f;
             }
             else


### PR DESCRIPTION
Fixes issue #180  by removing term t0 from chamberTemp non-combusting calculation. As far as I can tell, t0 is the ambient stagnation temperature? But I'm seeing it spike over 1000000K even sitting on the pad if an engine is decoupled. I usually see this on SRBs but have seen reports of it happening on liquid engines as well.