### PR TITLE
Analytic boiloff changes

### DIFF
--- a/Source/Engines/RFSettings.cs
+++ b/Source/Engines/RFSettings.cs
@@ -34,9 +34,9 @@ namespace RealFuels
         public double throttlingRate = 10d;
         public double throttlingClamp = 1.1d;
 
-        public static bool ferociousBoilOff = true;
-        public static bool globalConductionCompensation = false;
-        public static bool debugBoilOff = false;
+        public bool ferociousBoilOff = true;
+        public bool globalConductionCompensation = false;
+        public bool debugBoilOff = false;
 
         #region Ullage
         public bool simulateUllage = true;

--- a/Source/RealFuels.csproj
+++ b/Source/RealFuels.csproj
@@ -10,6 +10,7 @@
     <TargetFrameworkVersion>v3.5</TargetFrameworkVersion>
     <TargetFrameworkProfile />
     <ReleaseVersion>10.8.0</ReleaseVersion>
+    <BaseIntermediateOutputPath>..\..\Build\RealFuels\obj</BaseIntermediateOutputPath>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugType>full</DebugType>
@@ -48,10 +49,8 @@
       <HintPath>..\..\..\..\..\..\Games\RO_105\KSP_Data\Managed\Assembly-CSharp.dll</HintPath>
       <Private>False</Private>
     </Reference>
-    <Reference Include="UnityEngine.UI, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\..\..\..\Games\Steam\steamapps\common\Kerbal Space Program\KSP_x64_Data\Managed\UnityEngine.UI.dll</HintPath>
-      <Private>False</Private>
+    <Reference Include="UnityEngine.UI">
+      <HintPath>..\..\..\..\..\..\Games\RO_105\KSP_Data\Managed\UnityEngine.UI.dll</HintPath>
     </Reference>
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />

--- a/Source/RealFuels.userprefs
+++ b/Source/RealFuels.userprefs
@@ -1,20 +1,17 @@
 ﻿<Properties StartupItem="RealFuels.csproj">
   <MonoDevelop.Ide.Workspace ActiveConfiguration="Release" />
-  <MonoDevelop.Ide.Workbench ActiveDocument="Tanks\MFSSettings.cs">
-    <Files>
-      <File FileName="Engines\ModuleEnginesRF.cs" Line="409" Column="30" />
-      <File FileName="Tanks\ModuleFuelTanks.cs" Line="626" Column="50" />
-      <File FileName="Tanks\MFSSettings.cs" Line="105" Column="1" />
-      <File FileName="Tanks\FuelTank.cs" Line="318" Column="25" />
-      <File FileName="Tanks\FuelInfo.cs" Line="1" Column="1" />
-      <File FileName="Tanks\TankWindow.cs" Line="1" Column="1" />
-      <File FileName="Engines\SolverRF.cs" Line="1" Column="1" />
-      <File FileName="Engines\UpgradeManager.cs" Line="36" Column="17" />
-      <File FileName="Engines\ModuleEngineConfigs.cs" Line="206" Column="28" />
-    </Files>
-  </MonoDevelop.Ide.Workbench>
+  <MonoDevelop.Ide.DebuggingService.PinnedWatches />
   <MonoDevelop.Ide.DebuggingService.Breakpoints>
     <BreakpointStore />
   </MonoDevelop.Ide.DebuggingService.Breakpoints>
-  <MonoDevelop.Ide.DebuggingService.PinnedWatches />
+  <MonoDevelop.Ide.ItemProperties.RealFuels PreferredExecutionTarget="MonoDevelop.Default" />
+  <MonoDevelop.Ide.Workbench ActiveDocument="Tanks\ModuleFuelTanksRF.cs">
+    <Files>
+      <File FileName="Tanks\ModuleFuelTanksRF.cs" Line="192" Column="37" />
+      <File FileName="Engines\ModuleEnginesRF.cs" Line="692" Column="50" />
+      <File FileName="Tanks\FuelTank.cs" Line="60" Column="27" />
+      <File FileName="Utilities\ConfigNodeExtensions.cs" Line="1" Column="14" />
+      <File FileName="Engines\RFSettings.cs" Line="39" Column="15" />
+    </Files>
+  </MonoDevelop.Ide.Workbench>
 </Properties>

--- a/Source/Tanks/ModuleFuelTanksRF.cs
+++ b/Source/Tanks/ModuleFuelTanksRF.cs
@@ -12,6 +12,8 @@ namespace RealFuels.Tanks
         private double analyticSkinTemp;
         private double analyticInternalTemp;
         private double previewInternalFluxAdjust;
+        private bool supportsBoiloff = false;
+        public double sunAndBodyFlux = 0;
 
         public double outerInsulationFactor = 1.0;
 
@@ -22,6 +24,9 @@ namespace RealFuels.Tanks
         [KSPField(guiActiveEditor = true, guiName = "Highly Pressurized?")]
         public bool highlyPressurized = false;
 
+        [KSPField(isPersistant = false, guiActive = false, guiActiveEditor = false, guiName = "Wall Temp.", guiUnits = "")]
+        public string debug0Display;
+
         [KSPField(isPersistant = false, guiActive = false, guiActiveEditor = false, guiName = "Heat Penetration", guiUnits = "")]
         public string debug1Display;
 
@@ -31,12 +36,14 @@ namespace RealFuels.Tanks
         [KSPField(isPersistant = true)]
         public double partPrevTemperature = -1;
 
-        private static double ConductionFactors => RFSettings.globalConductionCompensation ? PhysicsGlobals.ConductionFactor : 1d;
+        private static double ConductionFactors => RFSettings.Instance.globalConductionCompensation ? Math.Max(1.0d, PhysicsGlobals.ConductionFactor) : 1d;
 
         public double BoiloffMassRate => boiloffMass;
 
 
         private FlightIntegrator _flightIntegrator;
+
+        double lowestTankTemperature = 300d;
 
         partial void OnStartRF(StartState state)
         {
@@ -58,13 +65,21 @@ namespace RealFuels.Tanks
             // changed from skin-internal to part.heatConductivity which affects
             part.heatConductivity = Math.Min(part.heatConductivity, outerInsulationFactor);
             // affects how fast internal temperatures change during analytic mode
-            part.analyticInternalInsulationFactor = outerInsulationFactor;
+            part.analyticInternalInsulationFactor *= outerInsulationFactor;
 
-            if (RFSettings.debugBoilOff)
+            for (int i = tankList.Count - 1; i >= 0; --i)
             {
-                Fields[nameof(debug1Display)].guiActive = true;
-                Fields[nameof(debug2Display)].guiActive = true;
+                FuelTank tank = tankList[i];
+                if (tank.maxAmount > 0.0 && (tank.vsp > 0.0 || tank.loss_rate > 0.0))
+                {
+                    supportsBoiloff = true;
+                    break;
+                }
             }
+
+            Fields[nameof(debug0Display)].guiActive = RFSettings.Instance.debugBoilOff && this.supportsBoiloff;
+            Fields[nameof(debug1Display)].guiActive = RFSettings.Instance.debugBoilOff && this.supportsBoiloff;
+            Fields[nameof(debug2Display)].guiActive = RFSettings.Instance.debugBoilOff && this.supportsBoiloff;
         }
 
         public void FixedUpdate()
@@ -72,51 +87,57 @@ namespace RealFuels.Tanks
             //print ("[Real Fuels]" + Time.time.ToString ());
             if (HighLogic.LoadedSceneIsFlight)
             {
-                if (RFSettings.debugBoilOff)
+                if (RFSettings.Instance.debugBoilOff)
                 {
                     //debug1Display = part.heatConductivity.ToString ("F12");
                     //debug2Display = FormatFlux (part.skinToInternalFlux);
                     debug1Display = "";
                     debug2Display = "";
+                    debug0Display = "";
                 }
                 if (tankArea == 0d)
                     CalculateTankArea(out tankArea);
 
                 // 
                 if(!_flightIntegrator.isAnalytical)
-                    StartCoroutine(CalculateTankLossFunction(TimeWarp.fixedDeltaTime));
+                    StartCoroutine(CalculateTankLossFunction((double)TimeWarp.fixedDeltaTime));
             }
         }
 
-        private IEnumerator CalculateTankLossFunction(float deltaTime, bool analyticalMode = false)
+        private IEnumerator CalculateTankLossFunction(double deltaTime, bool analyticalMode = false)
         {
             // Need to ensure that all heat compensation (radiators, heat pumps, etc) run first.
-            yield return new WaitForFixedUpdate();
+            if (!analyticalMode)
+                yield return new WaitForFixedUpdate();
+            
             boiloffMass = 0d;
-            double minTemp = 300d;
-            double coolingPool = part.thermalInternalFlux < 0.0d ? Math.Abs(part.thermalInternalFlux) : 0d;
-            double cooling = 0d;
+
+            previewInternalFluxAdjust = 0;
 
             for (int i = tankList.Count - 1; i >= 0; --i)
             {
                 FuelTank tank = tankList[i];
                 if (tank.amount > 0d && (tank.vsp > 0.0 || tank.loss_rate > 0d))
-                    minTemp = Math.Min(minTemp, tank.temperature);
+                    lowestTankTemperature = Math.Min(lowestTankTemperature, tank.temperature);
             }
 
-            if (tankList.Count > 0 && minTemp < 300d && MFSSettings.radiatorMinTempMult >= 0d)
-                part.radiatorMax = (minTemp * MFSSettings.radiatorMinTempMult) / part.maxTemp;
+            if (tankList.Count > 0 && lowestTankTemperature < 300d && MFSSettings.radiatorMinTempMult >= 0d)
+                part.radiatorMax = (lowestTankTemperature * MFSSettings.radiatorMinTempMult) / part.maxTemp;
 
             if (vessel != null && vessel.situation == Vessel.Situations.PRELAUNCH)
             {
-                part.temperature = minTemp;
-                part.skinTemperature = minTemp;
+                part.temperature = lowestTankTemperature;
+                part.skinTemperature = lowestTankTemperature;
             }
             else
             {
                 partPrevTemperature = part.temperature;
 
                 double deltaTimeRecip = 1d / deltaTime;
+                //Debug.Log("internalFlux = " + part.thermalInternalFlux.ToString() + ", thermalInternalFluxPrevious =" + part.thermalInternalFluxPrevious.ToString() + ", analytic internal flux = " + previewInternalFluxAdjust.ToString());
+
+                double cooling = Math.Min(0, part.thermalInternalFluxPrevious);
+
                 for (int i = tankList.Count - 1; i >= 0; --i)
                 {
                     FuelTank tank = tankList[i];
@@ -128,51 +149,48 @@ namespace RealFuels.Tanks
                             // Opposite of original boil off code. Finds massLost first.
                             double massLost = 0.0;
                             double deltaTemp;
-                            double hotTemp = analyticalMode ? analyticInternalTemp : part.temperature;
+                            double hotTemp = part.skinTemperature - (cooling * part.thermalMassReciprocal);
+                            double tankRatio = tank.maxAmount / volume;
 
-                            if (RFSettings.ferociousBoilOff)
-                                deltaTemp = ((hotTemp * part.thermalMass) - (tank.temperature * part.resourceThermalMass)) / (part.thermalMass - part.resourceThermalMass) - tank.temperature;
-                            else
-                                deltaTemp = hotTemp - tank.temperature;
+                            if (RFSettings.Instance.ferociousBoilOff)
+                                hotTemp = Math.Max(((hotTemp * part.thermalMass) - (tank.temperature * part.resourceThermalMass)) / (part.thermalMass - part.resourceThermalMass), part.temperature);
 
-                            if (RFSettings.debugBoilOff)
+                            deltaTemp = hotTemp - tank.temperature;
+
+                            if (RFSettings.Instance.debugBoilOff)
                             {
                                 if (debug2Display != "")
                                     debug2Display += " / ";
 
                                 if (debug1Display != "")
                                     debug1Display += " / ";
+                            
+                                if (debug0Display != "")
+                                    debug0Display += " / ";
                             }
 
+                            if (RFSettings.Instance.debugBoilOff)
+                                debug0Display += hotTemp.ToString("F6");
+                            
                             if (deltaTemp > 0)
                             {
-                                //double tankRatio = tank.maxAmount / volume;
-
                                 double wettedArea = tank.totalArea * (tank.amount / tank.maxAmount);
 
-                                double Q = deltaTemp / ((tank.wallThickness / (tank.wallConduction * wettedArea))
-                                                        + (tank.insulationThickness / (tank.insulationConduction * wettedArea))
-                                                        + (0.01 / (tank.resourceConductivity * wettedArea)));
-
-                                // Because any heat pumps that pulled heat out don't take effect until next physics frame...
-                                cooling = Math.Min(coolingPool, Q);
-                                coolingPool -= cooling;
-                                Q -= cooling;
+                                double Q = deltaTemp /
+                                    ((tank.wallThickness / (tank.wallConduction * wettedArea))
+                                     + (tank.insulationThickness / (tank.insulationConduction * wettedArea))
+                                     + (tank.resourceConductivity > 0 ? (0.01 / (tank.resourceConductivity * wettedArea)) : 0));
 
                                 Q *= 0.001d; // convert to kilowatts
 
                                 massLost = Q / tank.vsp;
 
-                                if (RFSettings.debugBoilOff)
+                                if (RFSettings.Instance.debugBoilOff)
                                 {
-                                    // Only do debugging displays if compiled for debugging.
+                                    // Only do debugging displays if debugging enabled in RFSettings
 
                                     debug1Display += Utilities.FormatFlux(Q);
                                     debug2Display += (massLost * 1000 * 3600).ToString("F4") + "kg/hr";
-                                    //debug2Display += area.ToString("F2");
-
-                                    //debug1Display = tank.wallThickness + " / " + tank.wallConduction;
-                                    //debug2Display = tank.insulationThickness + " / " + tank.insulationConduction;
                                 }
                                 massLost *= deltaTime; // Frame scaling
                             }
@@ -180,9 +198,10 @@ namespace RealFuels.Tanks
                             double lossAmount = massLost / tank.density;
 
                             if (double.IsNaN(lossAmount))
-                                Debug.Log("[RF] " + tank.name + " lossAmount is NaN!");
+                                print("[RF] " + tank.name + " lossAmount is NaN!");
                             else
                             {
+                                double heatLost = 0d;
                                 if (lossAmount > tank.amount)
                                 {
                                     tank.amount = 0d;
@@ -191,9 +210,9 @@ namespace RealFuels.Tanks
                                 {
                                     tank.amount -= lossAmount;
 
-                                    double fluxLost = -massLost * tank.vsp;
+                                    heatLost = -massLost * tank.vsp;
 
-                                    fluxLost *= ConductionFactors;
+                                    heatLost *= ConductionFactors;
 
                                     // See if there is boiloff byproduct and see if any other parts want to accept it.
                                     if (tank.boiloffProductResource != null)
@@ -205,11 +224,17 @@ namespace RealFuels.Tanks
 
                                     boiloffMass += massLost;
 
-                                    // subtract heat from boiloff
-                                    if (analyticalMode)
-                                        previewInternalFluxAdjust += fluxLost;
-                                    else
-                                        part.AddThermalFlux(fluxLost * deltaTimeRecip);
+                                }
+                                // subtract heat from boiloff
+                                // subtracting heat in analytic mode is tricky: Analytic flux handling is 'cheaty' and tricky to predict. 
+                                if (!analyticalMode)
+                                    part.AddThermalFlux(heatLost * deltaTimeRecip * 2.0d); // double because there is a bug in FlightIntegrator that cuts internal flux in half
+                                else
+                                {
+                                    analyticInternalTemp = analyticInternalTemp + (heatLost * part.thermalMassReciprocal);
+                                    previewInternalFluxAdjust -= heatLost * deltaTimeRecip * 2d;
+                                    if (deltaTime > 0)
+                                        print(part.name + " deltaTime = " + deltaTime + ", heat lost = " + heatLost + ", thermalMassReciprocal = " + part.thermalMassReciprocal);
                                 }
                             }
                         }
@@ -308,7 +333,7 @@ namespace RealFuels.Tanks
 
                         tank.totalArea = Math.Max(Math.Pow(Math.PI, 1.0 / 3.0) * Math.Pow((tankMaxAmount / 1000.0) * 6, 2.0 / 3.0), tank.totalArea = totalTankArea* tank.tankRatio);
 
-                        if (RFSettings.debugBoilOff)
+                        if (RFSettings.Instance.debugBoilOff)
                         {
                             Debug.Log("[RF] " + tank.name + ".tankRatio = " + tank.tankRatio.ToString());
                             Debug.Log("[RF] " + tank.name + ".maxAmount = " + tankMaxAmount.ToString());
@@ -320,12 +345,20 @@ namespace RealFuels.Tanks
             }
         }
 
-        #region Analytic Interfaces
+        #region IAnalyticTemperatureModifier
         // Analytic Interface
         public void SetAnalyticTemperature(FlightIntegrator fi, double analyticTemp, double toBeInternal, double toBeSkin)
         {
+            //if (analyticInternalTemp > lowestTankTemperature)
+            if(this.supportsBoiloff)
+                print(part.name + " Analytic Temp = " + analyticTemp.ToString() + ", Analytic Internal = " + toBeInternal.ToString() + ", Analytic Skin = " + toBeSkin.ToString());
+            
             analyticSkinTemp = toBeSkin;
             analyticInternalTemp = toBeInternal;
+            if (this.supportsBoiloff)
+            {
+                StartCoroutine(CalculateTankLossFunction(fi.timeSinceLastUpdate, true));
+            }
         }
 
         public double GetSkinTemperature(out bool lerp)
@@ -336,25 +369,39 @@ namespace RealFuels.Tanks
 
         public double GetInternalTemperature(out bool lerp)
         {
-            lerp = true;
+            // During analytic, pin our internal temperature. We'll figure out the difference and apply as much boiloff flux as needed for this to be valid.
+            if (supportsBoiloff)
+                lerp = true;
+            else
+                lerp = true;
             return analyticInternalTemp;
         }
+        #endregion
 
-        // Analytic Preview Interface
+        #region Analytic Preview Interface
         public void AnalyticInfo(FlightIntegrator fi, double sunAndBodyIn, double backgroundRadiation, double radArea, double absEmissRatio, double internalFlux, double convCoeff, double ambientTemp, double maxPartTemp)
         {
             if (_flightIntegrator != fi)
                 fi = _flightIntegrator;
-            //analyticalInternalFlux = internalFlux;
-            float deltaTime = (float)(Planetarium.GetUniversalTime() - vessel.lastUT);
-            CalculateTankLossFunction(deltaTime, true);
+
+            sunAndBodyFlux = sunAndBodyIn;
+            //previewInternalFluxAdjust = internalFlux;
+            //float deltaTime = (float)(Planetarium.GetUniversalTime() - vessel.lastUT);
+            //if (this.supportsBoiloff)
+            //{
+            //    StartCoroutine(CalculateTankLossFunction(TimeWarp.fixedDeltaTime, true));
+            //}
         }
 
         public double InternalFluxAdjust()
         {
             return previewInternalFluxAdjust;
         }
-
         #endregion
+
+        static void print(string msg)
+        {
+            MonoBehaviour.print("[RealFuels.ModuleFuelTankRF] " + msg);
+        }
     }
 }

--- a/Source/Tanks/ModuleFuelTanksRF.cs
+++ b/Source/Tanks/ModuleFuelTanksRF.cs
@@ -136,7 +136,6 @@ namespace RealFuels.Tanks
                 double deltaTimeRecip = 1d / deltaTime;
                 //Debug.Log("internalFlux = " + part.thermalInternalFlux.ToString() + ", thermalInternalFluxPrevious =" + part.thermalInternalFluxPrevious.ToString() + ", analytic internal flux = " + previewInternalFluxAdjust.ToString());
 
-                double cooling = Math.Min(0, part.thermalInternalFluxPrevious);
 
                 for (int i = tankList.Count - 1; i >= 0; --i)
                 {
@@ -149,7 +148,7 @@ namespace RealFuels.Tanks
                             // Opposite of original boil off code. Finds massLost first.
                             double massLost = 0.0;
                             double deltaTemp;
-                            double hotTemp = part.skinTemperature - (cooling * part.thermalMassReciprocal);
+                            double hotTemp = part.temperature - (cooling * part.thermalMassReciprocal);
                             double tankRatio = tank.maxAmount / volume;
 
                             if (RFSettings.Instance.ferociousBoilOff)


### PR DESCRIPTION
* Reinstating analytic handling of boiloff. part.temperature no longer 
frozen during analytic mode. part.analyticInternalInsulationFactor set 
based on tank.outerInsulationFactor (may need adjusting)
* Boiloff calculation uses InternalFluxAdjust during analytical mode 
instead of adjusting internal flux directly.
* Cached FlightIntegrator
* Reworked ferocial boil off mode (instead of adjusting Q based on 
calculated tank thermalMass / resourceThermalMass ratio, we properly  
calculate tank wall temperature by redistributing thermal energy from 
resource to part.  (KSP assumes part+resource thermal energy is just one 
homogenous temperature)