### PR TITLE
Pump changes

### DIFF
--- a/Source/Pumps/RefuelingPump.cs
+++ b/Source/Pumps/RefuelingPump.cs
@@ -100,39 +100,35 @@ namespace RealFuels
                     {
                         Tanks.FuelTank tank = m.tankList[j];
                         // if a tank isn't full, start filling it.
-                        PartResource r = tank.resource;
-                        if (r == null)
-                        {
-                            continue;
-                        }
-                        PartResourceDefinition d = PartResourceLibrary.Instance.GetDefinition(r.resourceName);
-                        if (d == null)
-                        {
-                            continue;
-                        }
-                        if (tank.maxAmount > 0d)
-                        {
-                            if (tank.loss_rate > 0d)
-                                minTemp = Math.Min(p.temperature, tank.temperature);
-                            if (tank.amount < tank.maxAmount && tank.fillable && r.flowMode != PartResource.FlowMode.None && d.resourceTransferMode == ResourceTransferMode.PUMP && r.flowState)
-                            {
-                                double amount = Math.Min(deltaTime * pump_rate * tank.utilization, tank.maxAmount - tank.amount);
-                                var game = HighLogic.CurrentGame;
 
-                                if (d.unitCost > 0 && game.Mode == Game.Modes.CAREER && Funding.Instance != null)
+                        if (tank.maxAmount <= 0) continue;
+
+                        PartResource r = tank.resource;
+                        if (r == null) continue;
+
+                        PartResourceDefinition d = PartResourceLibrary.Instance.GetDefinition(r.resourceName);
+                        if (d == null) continue;
+                        
+                        if (tank.loss_rate > 0d)
+                            minTemp = Math.Min(p.temperature, tank.temperature);
+                        if (tank.amount < tank.maxAmount && tank.fillable && r.flowMode != PartResource.FlowMode.None && d.resourceTransferMode == ResourceTransferMode.PUMP && r.flowState)
+                        {
+                            double amount = Math.Min(deltaTime * pump_rate * tank.utilization, tank.maxAmount - tank.amount);
+                            var game = HighLogic.CurrentGame;
+
+                            if (d.unitCost > 0 && game.Mode == Game.Modes.CAREER && Funding.Instance != null)
+                            {
+                                double funds = Funding.Instance.Funds;
+                                double cost = amount * d.unitCost;
+                                if (cost > funds)
                                 {
-                                    double funds = Funding.Instance.Funds;
-                                    double cost = amount * d.unitCost;
-                                    if (cost > funds)
-                                    {
-                                        amount = funds / d.unitCost;
-                                        cost = funds;
-                                    }
-                                    Funding.Instance.AddFunds(-cost, TransactionReasons.VesselRollout);
+                                    amount = funds / d.unitCost;
+                                    cost = funds;
                                 }
-                                //tank.amount = tank.amount + amount;
-                                p.TransferResource(r, amount, this.part);
+                                Funding.Instance.AddFunds(-cost, TransactionReasons.VesselRollout);
                             }
+                            //tank.amount = tank.amount + amount;
+                            p.TransferResource(r, amount, this.part);
                         }
                     }
                     p.temperature = minTemp;

--- a/Source/Pumps/RefuelingPump.cs
+++ b/Source/Pumps/RefuelingPump.cs
@@ -110,7 +110,7 @@ namespace RealFuels
                         if (d == null) continue;
                         
                         if (tank.loss_rate > 0d)
-                            minTemp = Math.Min(p.temperature, tank.temperature);
+                            minTemp = Math.Min(minTemp, tank.temperature);
                         if (tank.amount < tank.maxAmount && tank.fillable && r.flowMode != PartResource.FlowMode.None && d.resourceTransferMode == ResourceTransferMode.PUMP && r.flowState)
                         {
                             double amount = Math.Min(deltaTime * pump_rate * tank.utilization, tank.maxAmount - tank.amount);

--- a/Source/Pumps/RefuelingPump.cs
+++ b/Source/Pumps/RefuelingPump.cs
@@ -23,23 +23,20 @@ namespace RealFuels
             return "\nPump rate: " + pump_rate + "/s";
         }
 
-		IEnumerator WaitAndCheckLandedAt ()
-		{
-			yield return null;
-			if (vessel != null
-				&& vessel.LandedInKSC
-				&& Events != null) {
-				Events["TogglePump"].guiActive = true;
-			} else {
-				enablePump = false;
-			}
-		}
-
 		public override void OnStart (PartModule.StartState state)
 		{
 			if (HighLogic.LoadedSceneIsFlight) {
-				StartCoroutine (WaitAndCheckLandedAt ());
-			}
+                BaseField field = Fields[nameof(enablePump)];
+                if (vessel != null && vessel.LandedInKSC)
+                {
+                    field.guiActive = true;
+                }
+                else
+                {
+                    field.guiActive = false;
+                    enablePump = false;
+                }
+            }
 		}
 
         public void FixedUpdate ()

--- a/Source/Pumps/RefuelingPump.cs
+++ b/Source/Pumps/RefuelingPump.cs
@@ -88,12 +88,11 @@ namespace RealFuels
                 return;
 
             // now, let's look at what we're connected to.
-            for (int i = vessel.parts.Count - 1; i >= 0; --i ) // look through all parts
+            foreach (Part p in vessel.parts ) // look through all parts
             {
-                Part p = vessel.parts[i];
-                if (p.Modules.Contains("ModuleFuelTanks"))
+                Tanks.ModuleFuelTanks m = p.FindModuleImplementing<Tanks.ModuleFuelTanks>();
+                if (m != null)
                 {
-                    Tanks.ModuleFuelTanks m = (Tanks.ModuleFuelTanks)p.Modules["ModuleFuelTanks"];
                     double minTemp = p.temperature;
                     m.fueledByLaunchClamp = true;
                     // look through all tanks inside this part

--- a/Source/Pumps/RefuelingPump.cs
+++ b/Source/Pumps/RefuelingPump.cs
@@ -25,14 +25,21 @@ namespace RealFuels
             return "\nPump rate: " + pump_rate + "/s";
         }
 
-		public override void OnStart (PartModule.StartState state)
+		public override void OnStart(PartModule.StartState state)
 		{
 			if (HighLogic.LoadedSceneIsFlight)
             {
                 FindFlightIntegrator();
+            }
+        }
+
+        public override void OnStartFinished(PartModule.StartState state)
+        {
+            if (HighLogic.LoadedSceneIsFlight)
+            {
                 SetupGUI();
             }
-		}
+        }
 
         public void FixedUpdate ()
         {

--- a/Source/Pumps/RefuelingPump.cs
+++ b/Source/Pumps/RefuelingPump.cs
@@ -11,17 +11,12 @@ namespace RealFuels
 {
     public class RefuelingPump : PartModule
     {
-        [KSPField(isPersistant = true, guiActive = true, guiActiveEditor = true, guiName = "Pump Enabled")]
-        bool enablePump = false;
+        [KSPField(isPersistant = true, guiActive = true, guiActiveEditor = true, guiName = "Fuel Pump")]
+        [UI_Toggle(affectSymCounterparts = UI_Scene.Editor, disabledText = "Disabled", enabledText = "Enabled")]
+        bool enablePump = true;
 
         [KSPField(isPersistant = true)]
         double pump_rate = 100.0; // 100L/sec per resource
-
-        [KSPEvent(guiActive = false, guiActiveEditor = true, guiName = "Toggle Pump")]
-        public void TogglePump()
-        {
-            enablePump = !enablePump;
-        }
 
         public override string GetInfo ()
         {

--- a/Source/Tanks/ModuleFuelTanksRF.cs
+++ b/Source/Tanks/ModuleFuelTanksRF.cs
@@ -14,6 +14,7 @@ namespace RealFuels.Tanks
         private double previewInternalFluxAdjust;
         private bool supportsBoiloff = false;
         public double sunAndBodyFlux = 0;
+        public bool fueledByLaunchClamp = false;
 
         public double outerInsulationFactor = 0.0;
 
@@ -129,153 +130,151 @@ namespace RealFuels.Tanks
             if (tankList.Count > 0 && lowestTankTemperature < 300d && MFSSettings.radiatorMinTempMult >= 0d)
                 part.radiatorMax = (lowestTankTemperature * MFSSettings.radiatorMinTempMult) / part.maxTemp;
 
-            if (vessel != null && vessel.situation == Vessel.Situations.PRELAUNCH)
+            if (fueledByLaunchClamp)
             {
-                part.temperature = lowestTankTemperature;
-                part.skinTemperature = lowestTankTemperature;
+                fueledByLaunchClamp = false;
+                yield break;
             }
-            else
+
+            partPrevTemperature = part.temperature;
+
+            double deltaTimeRecip = 1d / deltaTime;
+            //Debug.Log("internalFlux = " + part.thermalInternalFlux.ToString() + ", thermalInternalFluxPrevious =" + part.thermalInternalFluxPrevious.ToString() + ", analytic internal flux = " + previewInternalFluxAdjust.ToString());
+
+            double cooling = analyticalMode ? Math.Min(0, part.thermalInternalFluxPrevious) : 0;
+
+            for (int i = tankList.Count - 1; i >= 0; --i)
             {
-                partPrevTemperature = part.temperature;
+                FuelTank tank = tankList[i];
 
-                double deltaTimeRecip = 1d / deltaTime;
-                //Debug.Log("internalFlux = " + part.thermalInternalFlux.ToString() + ", thermalInternalFluxPrevious =" + part.thermalInternalFluxPrevious.ToString() + ", analytic internal flux = " + previewInternalFluxAdjust.ToString());
-
-                double cooling = analyticalMode ? Math.Min(0, part.thermalInternalFluxPrevious) : 0;
-
-                for (int i = tankList.Count - 1; i >= 0; --i)
+                if (tank.amount > 0d)
                 {
-                    FuelTank tank = tankList[i];
-
-                    if (tank.amount > 0d)
+                    if (tank.vsp > 0.0 && tank.totalArea > 0)
                     {
-                        if (tank.vsp > 0.0 && tank.totalArea > 0)
+                        // Opposite of original boil off code. Finds massLost first.
+                        double massLost = 0.0;
+                        double deltaTemp;
+                        // should cache the insulation check as long as it's not liable to change between updates.
+                        bool hasMLI = part.heatConductivity < part.partInfo.partPrefab.heatConductivity;
+                        double hotTemp = (hasMLI ? part.temperature : part.skinTemperature) - (cooling * part.thermalMassReciprocal);
+                        double tankRatio = tank.maxAmount / volume;
+
+                        if (RFSettings.Instance.ferociousBoilOff)
+                            hotTemp = Math.Max(((hotTemp * part.thermalMass) - (tank.temperature * part.resourceThermalMass)) / (part.thermalMass - part.resourceThermalMass), part.temperature);
+
+                        deltaTemp = hotTemp - tank.temperature;
+
+                        if (RFSettings.Instance.debugBoilOff)
                         {
-                            // Opposite of original boil off code. Finds massLost first.
-                            double massLost = 0.0;
-                            double deltaTemp;
-                            // should cache the insulation check as long as it's not liable to change between updates.
-                            bool hasMLI = part.heatConductivity < part.partInfo.partPrefab.heatConductivity;
-                            double hotTemp =  (hasMLI ? part.temperature : part.skinTemperature) - (cooling * part.thermalMassReciprocal);
-                            double tankRatio = tank.maxAmount / volume;
+                            if (debug2Display != "")
+                                debug2Display += " / ";
 
-                            if (RFSettings.Instance.ferociousBoilOff)
-                                hotTemp = Math.Max(((hotTemp * part.thermalMass) - (tank.temperature * part.resourceThermalMass)) / (part.thermalMass - part.resourceThermalMass), part.temperature);
+                            if (debug1Display != "")
+                                debug1Display += " / ";
 
-                            deltaTemp = hotTemp - tank.temperature;
+                            if (debug0Display != "")
+                                debug0Display += " / ";
+                        }
+
+                        if (RFSettings.Instance.debugBoilOff)
+                            debug0Display += hotTemp.ToString("F6");
+
+                        if (deltaTemp > 0)
+                        {
+                            if (analyticalMode)
+                                print("Tank " + tank.name + " surface area = " + tank.totalArea);
+                            double wettedArea = tank.totalArea;// disabled until proper wetted vs ullage conduction can be done (tank.amount / tank.maxAmount);
+
+                            double Q = deltaTemp /
+                                ((tank.wallThickness / (tank.wallConduction * wettedArea))
+                                 + (tank.insulationThickness / (tank.insulationConduction * wettedArea))
+                                 + (tank.resourceConductivity > 0 ? (0.01 / (tank.resourceConductivity * wettedArea)) : 0));
+
+                            Q *= 0.001d; // convert to kilowatts
+
+                            massLost = Q / tank.vsp;
 
                             if (RFSettings.Instance.debugBoilOff)
                             {
-                                if (debug2Display != "")
-                                    debug2Display += " / ";
+                                // Only do debugging displays if debugging enabled in RFSettings
 
-                                if (debug1Display != "")
-                                    debug1Display += " / ";
-                            
-                                if (debug0Display != "")
-                                    debug0Display += " / ";
+                                debug1Display += Utilities.FormatFlux(Q);
+                                debug2Display += (massLost * 1000 * 3600).ToString("F4") + "kg/hr";
                             }
+                            massLost *= deltaTime; // Frame scaling
+                        }
 
-                            if (RFSettings.Instance.debugBoilOff)
-                                debug0Display += hotTemp.ToString("F6");
-                            
-                            if (deltaTemp > 0)
+                        double lossAmount = massLost / tank.density;
+
+                        if (double.IsNaN(lossAmount))
+                            print("[RF] " + tank.name + " lossAmount is NaN!");
+                        else
+                        {
+                            double heatLost = 0d;
+                            if (lossAmount > tank.amount)
                             {
-                                if (analyticalMode)
-                                    print("Tank " + tank.name + " surface area = " + tank.totalArea);
-                                double wettedArea = tank.totalArea;// disabled until proper wetted vs ullage conduction can be done (tank.amount / tank.maxAmount);
-
-                                double Q = deltaTemp /
-                                    ((tank.wallThickness / (tank.wallConduction * wettedArea))
-                                     + (tank.insulationThickness / (tank.insulationConduction * wettedArea))
-                                     + (tank.resourceConductivity > 0 ? (0.01 / (tank.resourceConductivity * wettedArea)) : 0));
-
-                                Q *= 0.001d; // convert to kilowatts
-
-                                massLost = Q / tank.vsp;
-
-                                if (RFSettings.Instance.debugBoilOff)
-                                {
-                                    // Only do debugging displays if debugging enabled in RFSettings
-
-                                    debug1Display += Utilities.FormatFlux(Q);
-                                    debug2Display += (massLost * 1000 * 3600).ToString("F4") + "kg/hr";
-                                }
-                                massLost *= deltaTime; // Frame scaling
+                                tank.amount = 0d;
                             }
-
-                            double lossAmount = massLost / tank.density;
-
-                            if (double.IsNaN(lossAmount))
-                                print("[RF] " + tank.name + " lossAmount is NaN!");
                             else
                             {
-                                double heatLost = 0d;
-                                if (lossAmount > tank.amount)
+                                tank.amount -= lossAmount;
+
+                                heatLost = -massLost * tank.vsp;
+
+                                heatLost *= ConductionFactors;
+
+                                // See if there is boiloff byproduct and see if any other parts want to accept it.
+                                if (tank.boiloffProductResource != null)
                                 {
-                                    tank.amount = 0d;
+                                    double boiloffProductAmount = -(massLost / tank.boiloffProductResource.density);
+                                    double retainedAmount = part.RequestResource(tank.boiloffProductResource.id, boiloffProductAmount, ResourceFlowMode.STAGE_PRIORITY_FLOW);
+                                    massLost -= retainedAmount * tank.boiloffProductResource.density;
                                 }
+
+                                boiloffMass += massLost;
+
+                            }
+                            // subtract heat from boiloff
+                            // subtracting heat in analytic mode is tricky: Analytic flux handling is 'cheaty' and tricky to predict. 
+                            // scratch sheet: example
+                            // [RealFuels.ModuleFuelTankRF] proceduralTankRealFuels Analytic Temp = 256.679360297684, Analytic Internal = 256.679360297684, Analytic Skin = 256.679360297684
+                            // [RealFuels.ModuleFuelTankRF] proceduralTankRealFuels deltaTime = 17306955.5092776, heat lost = 6638604.21227684, thermalMassReciprocal = 0.00444787360733243
+
+                            if (!analyticalMode)
+                            {
+                                if (hasMLI)
+                                    part.AddThermalFlux(heatLost * deltaTimeRecip * 2.0d); // double because there is a bug in FlightIntegrator that cuts added flux in half
                                 else
-                                {
-                                    tank.amount -= lossAmount;
+                                    part.AddSkinThermalFlux(heatLost * deltaTimeRecip * 2.0d); // double because there is a bug in FlightIntegrator that cuts added flux in half
 
-                                    heatLost = -massLost * tank.vsp;
-
-                                    heatLost *= ConductionFactors;
-
-                                    // See if there is boiloff byproduct and see if any other parts want to accept it.
-                                    if (tank.boiloffProductResource != null)
-                                    {
-                                        double boiloffProductAmount = -(massLost / tank.boiloffProductResource.density);
-                                        double retainedAmount = part.RequestResource(tank.boiloffProductResource.id, boiloffProductAmount, ResourceFlowMode.STAGE_PRIORITY_FLOW);
-                                        massLost -= retainedAmount * tank.boiloffProductResource.density;
-                                    }
-
-                                    boiloffMass += massLost;
-
-                                }
-                                // subtract heat from boiloff
-                                // subtracting heat in analytic mode is tricky: Analytic flux handling is 'cheaty' and tricky to predict. 
-                                // scratch sheet: example
-// [RealFuels.ModuleFuelTankRF] proceduralTankRealFuels Analytic Temp = 256.679360297684, Analytic Internal = 256.679360297684, Analytic Skin = 256.679360297684
-// [RealFuels.ModuleFuelTankRF] proceduralTankRealFuels deltaTime = 17306955.5092776, heat lost = 6638604.21227684, thermalMassReciprocal = 0.00444787360733243
-
-                                if (!analyticalMode)
-                                {
-                                    if (hasMLI)
-                                        part.AddThermalFlux(heatLost * deltaTimeRecip * 2.0d); // double because there is a bug in FlightIntegrator that cuts added flux in half
-                                    else
-                                        part.AddSkinThermalFlux(heatLost * deltaTimeRecip * 2.0d); // double because there is a bug in FlightIntegrator that cuts added flux in half
-
-                                }
-                                else
-                                {
-                                    analyticInternalTemp = analyticInternalTemp + (heatLost * part.thermalMassReciprocal);
-                                    previewInternalFluxAdjust -= heatLost * deltaTimeRecip;
-                                    if (deltaTime > 0)
-                                        print(part.name + " deltaTime = " + deltaTime + ", heat lost = " + heatLost + ", thermalMassReciprocal = " + part.thermalMassReciprocal);
-                                }
+                            }
+                            else
+                            {
+                                analyticInternalTemp = analyticInternalTemp + (heatLost * part.thermalMassReciprocal);
+                                previewInternalFluxAdjust -= heatLost * deltaTimeRecip;
+                                if (deltaTime > 0)
+                                    print(part.name + " deltaTime = " + deltaTime + ", heat lost = " + heatLost + ", thermalMassReciprocal = " + part.thermalMassReciprocal);
                             }
                         }
-                        else if (tank.loss_rate > 0 && tank.amount > 0)
+                    }
+                    else if (tank.loss_rate > 0 && tank.amount > 0)
+                    {
+                        double deltaTemp = part.temperature - tank.temperature;
+                        if (deltaTemp > 0)
                         {
-                            double deltaTemp = part.temperature - tank.temperature;
-                            if (deltaTemp > 0)
+                            double lossAmount = tank.maxAmount * tank.loss_rate * deltaTemp * deltaTime;
+                            if (lossAmount > tank.amount)
                             {
-                                double lossAmount = tank.maxAmount * tank.loss_rate * deltaTemp * deltaTime;
-                                if (lossAmount > tank.amount)
-                                {
-                                    lossAmount = -tank.amount;
-                                    tank.amount = 0d;
-                                }
-                                else
-                                {
-                                    lossAmount = -lossAmount;
-                                    tank.amount += lossAmount;
-                                }
-                                double massLost = tank.density * lossAmount;
-                                boiloffMass += massLost;
+                                lossAmount = -tank.amount;
+                                tank.amount = 0d;
                             }
+                            else
+                            {
+                                lossAmount = -lossAmount;
+                                tank.amount += lossAmount;
+                            }
+                            double massLost = tank.density * lossAmount;
+                            boiloffMass += massLost;
                         }
                     }
                 }
@@ -390,10 +389,9 @@ namespace RealFuels.Tanks
             
             analyticSkinTemp = toBeSkin;
             analyticInternalTemp = toBeInternal;
-            if (this.supportsBoiloff)
-            {
+
+            if (this.supportsBoiloff && fi.timeSinceLastUpdate < double.MaxValue * 0.99)
                 StartCoroutine(CalculateTankLossFunction(fi.timeSinceLastUpdate, true));
-            }
         }
 
         public double GetSkinTemperature(out bool lerp)


### PR DESCRIPTION
* Fuel pumps must now be present and active in order to avoid boiloff during prelaunch (previously being on the launch pad was enough)
* Fuel pumps are now enabled by default and enabled setting respects symmetry in the editor
* Streamline fuel pump enable/disable UI - now a simple button rather than display + button