### PR TITLE
Boiloff fix

### DIFF
--- a/Source/Pumps/RefuelingPump.cs
+++ b/Source/Pumps/RefuelingPump.cs
@@ -100,7 +100,6 @@ namespace RealFuels
                 Tanks.ModuleFuelTanks m = p.FindModuleImplementing<Tanks.ModuleFuelTanks>();
                 if (m != null)
                 {
-                    double minTemp = p.temperature;
                     m.fueledByLaunchClamp = true;
                     // look through all tanks inside this part
                     for (int j = m.tankList.Count - 1; j >= 0; --j)
@@ -116,8 +115,6 @@ namespace RealFuels
                         PartResourceDefinition d = PartResourceLibrary.Instance.GetDefinition(r.resourceName);
                         if (d == null) continue;
                         
-                        if (tank.loss_rate > 0d)
-                            minTemp = Math.Min(minTemp, tank.temperature);
                         if (tank.amount < tank.maxAmount && tank.fillable && r.flowMode != PartResource.FlowMode.None && d.resourceTransferMode == ResourceTransferMode.PUMP && r.flowState)
                         {
                             double amount = Math.Min(deltaTime * pump_rate * tank.utilization, tank.maxAmount - tank.amount);
@@ -138,7 +135,6 @@ namespace RealFuels
                             p.TransferResource(r, amount, this.part);
                         }
                     }
-                    p.temperature = minTemp;
                 }
                 else
                 {

--- a/Source/Tanks/ModuleFuelTanksRF.cs
+++ b/Source/Tanks/ModuleFuelTanksRF.cs
@@ -223,8 +223,6 @@ namespace RealFuels.Tanks
 
                             heatLost = -massLost * tank.vsp;
 
-                            heatLost *= ConductionFactors;
-
                             // See if there is boiloff byproduct and see if any other parts want to accept it.
                             if (tank.boiloffProductResource != null)
                             {
@@ -244,6 +242,8 @@ namespace RealFuels.Tanks
 
                         if (!analyticalMode)
                         {
+                            heatLost *= ConductionFactors;
+
                             if (hasMLI)
                                 part.AddThermalFlux(heatLost * deltaTimeRecip * 2.0d); // double because there is a bug in FlightIntegrator that cuts added flux in half
                             else

--- a/Source/Tanks/ModuleFuelTanksRF.cs
+++ b/Source/Tanks/ModuleFuelTanksRF.cs
@@ -253,7 +253,7 @@ namespace RealFuels.Tanks
                         else
                         {
                             analyticInternalTemp = analyticInternalTemp + (heatLost * part.thermalMassReciprocal);
-                            previewInternalFluxAdjust -= heatLost * deltaTimeRecip;
+                            previewInternalFluxAdjust += heatLost * deltaTimeRecip;
 #if DEBUG
                             if (deltaTime > 0)
                                 print(part.name + " deltaTime = " + deltaTime + ", heat lost = " + heatLost + ", thermalMassReciprocal = " + part.thermalMassReciprocal);

--- a/Source/Tanks/ModuleFuelTanksRF.cs
+++ b/Source/Tanks/ModuleFuelTanksRF.cs
@@ -177,8 +177,11 @@ namespace RealFuels.Tanks
 
                     if (deltaTemp > 0)
                     {
+#if DEBUG
                         if (analyticalMode)
                             print("Tank " + tank.name + " surface area = " + tank.totalArea);
+#endif
+
                         double wettedArea = tank.totalArea;// disabled until proper wetted vs ullage conduction can be done (tank.amount / tank.maxAmount);
 
                         double Q = deltaTemp /
@@ -248,8 +251,10 @@ namespace RealFuels.Tanks
                         {
                             analyticInternalTemp = analyticInternalTemp + (heatLost * part.thermalMassReciprocal);
                             previewInternalFluxAdjust -= heatLost * deltaTimeRecip;
+#if DEBUG
                             if (deltaTime > 0)
                                 print(part.name + " deltaTime = " + deltaTime + ", heat lost = " + heatLost + ", thermalMassReciprocal = " + part.thermalMassReciprocal);
+#endif
                         }
                     }
                 }
@@ -392,8 +397,10 @@ namespace RealFuels.Tanks
         public void SetAnalyticTemperature(FlightIntegrator fi, double analyticTemp, double toBeInternal, double toBeSkin)
         {
             //if (analyticInternalTemp > lowestTankTemperature)
+#if DEBUG
             if(this.supportsBoiloff)
                 print(part.name + " Analytic Temp = " + analyticTemp.ToString() + ", Analytic Internal = " + toBeInternal.ToString() + ", Analytic Skin = " + toBeSkin.ToString());
+#endif
             
             analyticSkinTemp = toBeSkin;
             analyticInternalTemp = toBeInternal;

--- a/Source/Tanks/ModuleFuelTanksRF.cs
+++ b/Source/Tanks/ModuleFuelTanksRF.cs
@@ -102,7 +102,7 @@ namespace RealFuels.Tanks
                     debug0Display = "";
                 }
 
-                if(!_flightIntegrator.isAnalytical)
+                if(!_flightIntegrator.isAnalytical && supportsBoiloff)
                     StartCoroutine(CalculateTankLossFunction((double)TimeWarp.fixedDeltaTime));
             }
         }


### PR DESCRIPTION
My recent changes to launch clamp behavior caused tanks to start near 300K rather than fuel temperature.  This causes higher boiloff (initially) than you should have.