### PR TITLE
[Mod Support] Update for the KSP 1.4 tanks

### DIFF
--- a/RealFuels/Squad_modularFuelTanks.cfg
+++ b/RealFuels/Squad_modularFuelTanks.cfg
@@ -279,7 +279,7 @@
 	}
 }
 
-@PART[toroidalFuelTank|externalTankRound]:FOR[RealFuels]
+@PART[externalTankRound]:FOR[RealFuels]
 {
 	MODULE
 	{
@@ -299,7 +299,7 @@
 	}
 }
 
-@PART[externalTankToroid]:FOR[RealFuels]
+@PART[toroidalFuelTank|externalTankToroid]:FOR[RealFuels]
 {
 	MODULE
 	{

--- a/RealFuels/Squad_modularFuelTanks.cfg
+++ b/RealFuels/Squad_modularFuelTanks.cfg
@@ -20,7 +20,7 @@
 	}
 }
 
-@PART[fuelTank1-2]:FOR[RealFuels]
+@PART[fuelTank1-2|Rockomax32_BW]:FOR[RealFuels]
 {
 	MODULE
 	{
@@ -30,7 +30,7 @@
 	}
 }
 
-@PART[fuelTank2-2]:FOR[RealFuels]
+@PART[fuelTank2-2|Rockomax16_BW]:FOR[RealFuels]
 {
 	MODULE
 	{
@@ -40,7 +40,7 @@
 	}
 }
 
-@PART[fuelTank3-2]:FOR[RealFuels]
+@PART[fuelTank3-2|Rockomax64_BW]:FOR[RealFuels]
 {
 	MODULE
 	{
@@ -50,7 +50,7 @@
 	}
 }
 
-@PART[fuelTank4-2]:FOR[RealFuels]
+@PART[fuelTank4-2|Rockomax8BW]:FOR[RealFuels]
 {
 	MODULE
 	{
@@ -279,7 +279,27 @@
 	}
 }
 
-@PART[toroidalFuelTank]:FOR[RealFuels]
+@PART[toroidalFuelTank|externalTankRound]:FOR[RealFuels]
+{
+	MODULE
+	{
+		name = ModuleFuelTanks
+		volume = 85
+		type = Cryogenic
+	}
+}
+
+@PART[externalTankCapsule]:FOR[RealFuels]
+{
+	MODULE
+	{
+		name = ModuleFuelTanks
+		volume = 284
+		type = Cryogenic
+	}
+}
+
+@PART[externalTankToroid]:FOR[RealFuels]
 {
 	MODULE
 	{
@@ -442,8 +462,6 @@
 	}
 }
 
-
-
 @PART[mk2DockingPort]:FOR[RealFuels]
 {
 	MODULE
@@ -487,6 +505,7 @@
 		type = Fuselage
 	}
 }
+
 @PART[radialEngineBody]:FOR[RealFuels]
 {
 	MODULE
@@ -497,6 +516,7 @@
 		type = Fuselage
 	}
 }
+
 @PART[MK1IntakeFuselage]:FOR[RealFuels]
 {
 	MODULE
@@ -514,6 +534,16 @@
 	{
 		name = ModuleFuelTanks
 		volume = 250
+		type = Fuselage
+	}
+}
+
+@PART[noseConeAdapter]:FOR[RealFuels]
+{
+	MODULE
+	{
+		name = ModuleFuelTanks
+		volume = 1420
 		type = Fuselage
 	}
 }

--- a/RealFuels/Squad_modularFuelTanks.cfg
+++ b/RealFuels/Squad_modularFuelTanks.cfg
@@ -284,7 +284,7 @@
 	MODULE
 	{
 		name = ModuleFuelTanks
-		volume = 85
+		volume = 100
 		type = Cryogenic
 	}
 }
@@ -294,7 +294,7 @@
 	MODULE
 	{
 		name = ModuleFuelTanks
-		volume = 284
+		volume = 330
 		type = Cryogenic
 	}
 }
@@ -543,7 +543,7 @@
 	MODULE
 	{
 		name = ModuleFuelTanks
-		volume = 1420
+		volume = 1400
 		type = Fuselage
 	}
 }


### PR DESCRIPTION
**Change Log:**

* Add the new Rockomax and toroidal tank patches as subsets of the old ones (identical parts).
* Add patches for the new spherical and capsule tanks.
* Add patch for the missed NCS Adapter tank.

**Notes:**

* Volumes were calculated based upon the model mesh dimensions and adjusted to be 86% of the overall tank volume. This may be a completely wrong assumption though so some feedback is required.