### PR TITLE
Missing Version file added

### DIFF
--- a/ModularFuelTanks/ModularFuelTanks.version
+++ b/ModularFuelTanks/ModularFuelTanks.version
@@ -1,0 +1,21 @@
+{
+    "NAME": "ModularFuelTanks",
+    "URL": "https://github.com/NathanKell/ModularFuelSystem/blob/master/ModularFuelTanks/ModularFuelTanks.version",
+    "DOWNLOAD": "http://forum.kerbalspaceprogram.com/index.php?/topic/58235-11-modular-fuel-tanks-v570/",
+    "VERSION":{
+        "MAJOR": 0,
+        "MINOR": 5,
+        "PATCH": 11,
+        "BUILD": 0
+    },
+    "KSP_VERSION_MIN": {
+        "MAJOR": 1,
+        "MINOR": 4,
+        "PATCH": 1
+    },
+    "KSP_VERSION_MAX": {
+        "MAJOR": 1,
+        "MINOR": 4,
+        "PATCH": 99
+    }
+}


### PR DESCRIPTION
I noticed that Ckan was showing the data incorrectly for the newest revision that was compiled for KSP 1.4.1 and works (Very well) in even KSP 1.4.9. This caused an annoying error message on startup as well as having to force overrides in Ckan to load the mod. So, I created a "version" file based on the change notes listed in the thread as well as updated the download link for GitHub and the forum posting "Home" URL where the original link and verification of recompiling for 1.4.1 was done. Everything shows up in Ckan correctly now. Yay!