### PR TITLE
Gui perf fixes

### DIFF
--- a/Source/Tanks/ModuleFuelTanks.cs
+++ b/Source/Tanks/ModuleFuelTanks.cs
@@ -1100,6 +1100,7 @@ namespace RealFuels.Tanks
 					}
 				}
 			}
+			GameEvents.onEditorShipModified.Fire (EditorLogic.fetch.ship);
 		}
 
         List<Propellant> GetEnginePropellants(PartModule engine)

--- a/Source/Tanks/TankWindow.cs
+++ b/Source/Tanks/TankWindow.cs
@@ -39,6 +39,10 @@ namespace RealFuels.Tanks
 		bool ActionGroupMode;
 		ModuleFuelTanks tank_module;
 
+		Dictionary<string, string> addLabelCache = new Dictionary<string, string>();
+		double oldAvailableVolume = 0;
+		string oldTankType = "newnewnew"; //force refresh on first call to EnsureFreshAddLabelCache()
+
 		public static void HideGUI ()
 		{
 			if (instance != null) {
@@ -64,6 +68,20 @@ namespace RealFuels.Tanks
             EditorLogic editor = EditorLogic.fetch;
             if(!enabled &&  editor != null)
                 editor.Unlock("MFTGUILock");
+		}
+
+		void EnsureFreshAddLabelCache()
+		{
+			if (tank_module.AvailableVolume != oldAvailableVolume || tank_module.type != oldTankType){
+				foreach (FuelTank tank in tank_module.tankList) {
+					double maxVol = tank_module.AvailableVolume * tank.utilization;
+					string maxVolStr = KSPUtil.PrintSI(maxVol, "L");
+					string label = "Max: " + maxVolStr + " (+" + ModuleFuelTanks.FormatMass((float)(tank_module.AvailableVolume * tank.mass)) + " )";
+					addLabelCache[tank.name] = label;
+				}
+				oldAvailableVolume = tank_module.AvailableVolume;
+				oldTankType = tank_module.type;
+			}
 		}
 
 		private void onEditorLoad (ShipConstruct ship, CraftBrowserDialog.LoadType loadType)
@@ -321,11 +339,7 @@ namespace RealFuels.Tanks
 
 		void AddTank (FuelTank tank)
 		{
-			double maxVol = tank_module.AvailableVolume * tank.utilization;
-			string maxVolStr = KSPUtil.PrintSI (maxVol, "L");
-			string extraData = "Max: " + maxVolStr + " (+" + ModuleFuelTanks.FormatMass ((float) (tank_module.AvailableVolume * tank.mass)) + " )";
-
-			GUILayout.Label (extraData, GUILayout.Width (150));
+			GUILayout.Label (addLabelCache[tank.name], GUILayout.Width (150));
 
 			if (GUILayout.Button ("Add", GUILayout.Width (120))) {
 				tank.maxAmount = tank_module.AvailableVolume * tank.utilization;
@@ -375,6 +389,7 @@ namespace RealFuels.Tanks
 
         private void GUITanks ()
         {
+			EnsureFreshAddLabelCache();
 			foreach (FuelTank tank in tank_module.tankList) {
                 if (tank.canHave)
                     TankLine(tank);

--- a/Source/Tanks/TankWindow.cs
+++ b/Source/Tanks/TankWindow.cs
@@ -288,6 +288,7 @@ namespace RealFuels.Tanks
 						}
 					}
 				}
+				GameEvents.onEditorShipModified.Fire (EditorLogic.fetch.ship);
 			}
 		}
 
@@ -316,7 +317,6 @@ namespace RealFuels.Tanks
 
 			UpdateTank (tank);
 			RemoveTank (tank);
-            GameEvents.onEditorShipModified.Fire(EditorLogic.fetch.ship);
         }
 
 		void AddTank (FuelTank tank)
@@ -332,6 +332,7 @@ namespace RealFuels.Tanks
 				tank.amount = tank.fillable ? tank.maxAmount : 0;
 
 				tank.maxAmountExpression = tank.maxAmount.ToString ();
+				GameEvents.onEditorShipModified.Fire (EditorLogic.fetch.ship);
 				//Debug.LogWarning ("[MFT] Adding tank " + tank.name + " maxAmount: " + tank.maxAmountExpression ?? "null");
 			}
 		}


### PR DESCRIPTION
Primarily, this PR stops the frequent FAR re-voxelizations reported in #221.  That issue also seemed to be associated with garbage collection stalls on my machine, but I don't know why. Heap fragmentation from FAR maybe?

After that was dealt with, the GUI was noticiably laggier with **un**configured tanks than with configured ones.  Some part of formatting the potential tank volume and resource mass for display is apparently expensive, so I hoisted it out of OnGUI.

Finally, the formula for calculating masses of additional tank options was not right.  It's still off by a tiny bit, I think because adding resources changes dry mass, but it's a lot better.