### PR TITLE
Added option that allows unlocking TankDefinition with a PartUpgrade

### DIFF
--- a/Source/Tanks/TankDefinition.cs
+++ b/Source/Tanks/TankDefinition.cs
@@ -17,8 +17,18 @@ namespace RealFuels.Tanks
 		[Persistent]
 		public string baseCost;
 
+        /// <summary>
+        /// Name of the tech node that needs to be unlocked before the current tank definition becomes selectable.
+        /// This field will not be checked if partUpgradeRequired is filled at the same time as this.
+        /// </summary>
         [Persistent]
         public string techRequired = "";
+
+        /// <summary>
+        /// Name of the part upgrade that needs to be unlocked before the current tank definition becomes selectable.
+        /// </summary>
+        [Persistent]
+        public string partUpgradeRequired = "";
 
         [Persistent]
         public bool highlyPressurized = false;
@@ -77,10 +87,21 @@ namespace RealFuels.Tanks
         {
             get
             {
-                if (techRequired.Equals("") || HighLogic.CurrentGame == null || HighLogic.CurrentGame.Mode == Game.Modes.SANDBOX)
+                if (HighLogic.CurrentGame == null || HighLogic.CurrentGame.Mode == Game.Modes.SANDBOX)
                     return true;
-                return ResearchAndDevelopment.GetTechnologyState(techRequired) == RDTech.State.Available;
+
+                if (!string.IsNullOrEmpty(partUpgradeRequired) &&
+                    HighLogic.CurrentGame.Parameters.CustomParams<GameParameters.AdvancedParams>().PartUpgradesInCareer)
+                {
+                    return PartUpgradeManager.Handler.IsUnlocked(partUpgradeRequired);
+                }
+                else if (!string.IsNullOrEmpty(techRequired))
+                {
+                    return ResearchAndDevelopment.GetTechnologyState(techRequired) == RDTech.State.Available;
+                }
+
+                return true;
             }
         }
-	}
+    }
 }


### PR DESCRIPTION
It would be used in RP-1 for requiring the player to pay an entry cost before a tank definition becomes selectable.