### PR TITLE
Update for KSP 1.8

### DIFF
--- a/Source/Makefile
+++ b/Source/Makefile
@@ -56,11 +56,11 @@ info:
 bin/modularFuelTanks.dll: ${MFT_FILES}
 	@mkdir -p bin
 	${GMCS} /highentropyva- /noconfig /nostdlib+ /t:library \
-		/r:/usr/lib/mono/2.0-api/mscorlib.dll \
-		/r:/usr/lib/mono/2.0-api/System.Core.dll \
+		/r:/usr/lib/mono/4.5-api/mscorlib.dll \
+		/r:/usr/lib/mono/4.5-api/System.Core.dll \
 		/lib:${MANAGED} \
 		/r:Assembly-CSharp.dll,Assembly-CSharp-firstpass.dll \
-		/r:UnityEngine.dll,UnityEngine.UI.dll \
+		/r:UnityEngine.dll,UnityEngine.UI.dll,UnityEngine.CoreModule.dll,UnityEngine.IMGUIModule.dll,UnityEngine.TextRenderingModule.dll,UnityEngine.InputLegacyModule.dll \
 		/out:$@ $^
 
 bin/TweakScale_ModularFuelTanks.dll: ${MFT_TS_FILES} bin/modularFuelTanks.dll

--- a/Source/assembly/Checkers.cs
+++ b/Source/assembly/Checkers.cs
@@ -65,7 +65,7 @@ namespace RealFuels
             // can expect a future update to be available.
             //
 			if (Versioning.version_major != 1
-				|| Versioning.version_minor != 7) {
+				|| Versioning.version_minor != 8) {
 				return false;
 			}
 


### PR DESCRIPTION
This PR makes the minimal required changes to make this mod work on KSP 1.8. I am a Linux user and have no access to a Windows machine to test or build there. I was also unable to get the IDE solution to work at all on MonoDevelop. I suspect this last issue is just my own lack of knowledge of how MonoDevelop works.

Here is my testing plan (checked items are already done):
 
- [x] The presence of the MFT module on the appropriate parts.
- [x] The usability of the Tank UI.
- [x] The usability of the "quick add" buttons and their appearance with the appropriate engines.
- [x] In flight behavior of tanks.
- [x] Usage on a clean install.
- [x] Usage on an existing save game upgraded from 1.7.
- [x] Linux
- [ ] Windows **(I cannot test this)**

Tell me if there is anything I could to do help with this.

PS: I'm mostly just scratching my own itch, as with many open-source contributions, so I will happily just use my local build, so no need to rush this.