### PR TITLE
Fix missing comma in version file

### DIFF
--- a/RealFuels/RealFuels.version
+++ b/RealFuels/RealFuels.version
@@ -5,7 +5,7 @@
 	{
 		"MAJOR": 12,
 		"MINOR": 8,
-		"PATCH": 4
+		"PATCH": 4,
 		"BUILD": 1
 	},
 	"KSP_VERSION":


### PR DESCRIPTION
The version file currently has a syntax error, a comma is missing.
Now it's fixed.

In case you're interested, @DasSkelett has developed a version file validator plugin for GitHub that can catch things like this before release, might be worth trying out:

- https://github.com/DasSkelett/AVC-VersionFileValidator