### PR TITLE
Show more appropriate units for thrust in module display info

### DIFF
--- a/Source/Engines/ModuleEngineConfigs.cs
+++ b/Source/Engines/ModuleEngineConfigs.cs
@@ -420,7 +420,7 @@ namespace RealFuels
                 info += "    " + config.GetValue("tfRatedBurnTime") + "\n";
             if (config.HasValue(thrustRating))
             {
-                info += "    " + (scale * ThrustTL(config.GetValue(thrustRating), config)).ToString("0.###") + " kN";
+                info += "    " + Utilities.FormatThrust(scale * ThrustTL(config.GetValue(thrustRating), config));
                 // add throttling info if present
                 if (config.HasValue("minThrust"))
                     info += ", min " + (float.Parse(config.GetValue("minThrust")) / float.Parse(config.GetValue(thrustRating)) * 100f).ToString("N0") + "%";
@@ -680,7 +680,7 @@ namespace RealFuels
                 {
                     // Changed this to find ALL RCS modules on the part to address SSTU case where MUS with only aft RCS is not handled.
                     List<ModuleRCS> RCSModules = part.Modules.OfType<ModuleRCS>().ToList();
-                    
+
                     if (RCSModules.Count > 0)
                     {
                         DoConfig(config);
@@ -1034,7 +1034,7 @@ namespace RealFuels
             // heat update
             if(configHeat >= 0f)
                 cfg.SetValue("heatProduction", configHeat.ToString("0"), true);
-            
+
             // mass change
             if (origMass > 0)
             {
@@ -1260,7 +1260,7 @@ namespace RealFuels
         private int counterTT;
         private bool styleSetup = false;
         private bool editorLocked = false;
-        
+
         public void OnGUI()
         {
             if (!compatible || !isMaster || !HighLogic.LoadedSceneIsEditor || EditorLogic.fetch == null)
@@ -1272,7 +1272,7 @@ namespace RealFuels
                 editorUnlock();
                 return;
             }
-            
+
             if (inPartsEditor)
             {
                 List<Part> symmetryParts = part.symmetryCounterparts;
@@ -1295,7 +1295,7 @@ namespace RealFuels
                 int posMult = (offsetGUIPos == -1) ? (part.Modules.Contains("ModuleFuelTanks") ? 1 : 0) : offsetGUIPos;
                 guiWindowRect = new Rect(posAdd + 430 * posMult, 365, 430, (Screen.height - 365));
             }
-            
+
             mousePos = Input.mousePosition; //Mouse location; based on Kerbal Engineer Redux code
             mousePos.y = Screen.height - mousePos.y;
             if (guiWindowRect.Contains(mousePos))

--- a/Source/Engines/ModuleEnginesRF.cs
+++ b/Source/Engines/ModuleEnginesRF.cs
@@ -35,7 +35,7 @@ namespace RealFuels
         [KSPField]
         public float throttleClamp = 0.005f;
 
-        
+
 
         #region Thrust Curve
         //[KSPField]
@@ -106,7 +106,7 @@ namespace RealFuels
                 atmCurve = null;
             if(!useVelCurve)
                 velCurve = null;
-            
+
             // FIXME quick temp hax
             if (useAtmCurve)
             {
@@ -145,9 +145,9 @@ namespace RealFuels
                 flowMultCapSharpness,
                 thrustVariation,
                 (float)part.name.GetHashCode());
-            
+
             rfSolver.SetScale(scale);
-            
+
             engineSolver = rfSolver;
         }
         public override void OnAwake()
@@ -297,7 +297,7 @@ namespace RealFuels
         public override void OnStart(PartModule.StartState state)
         {
             base.OnStart(state);
-            
+
             Fields["thrustCurveDisplay"].guiActive = useThrustCurve && state != StartState.Editor;
         }
         bool needSetPropStatus = true;
@@ -385,7 +385,7 @@ namespace RealFuels
 
             actualThrottle = (int)(currentThrottle * 100f);
         }
-        
+
         // from SolverEngines but we don't play FX here.
         public override void Activate()
         {
@@ -542,20 +542,20 @@ namespace RealFuels
             {
                 if (throttleLocked || minThrottle == 1f)
                 {
-                    output += String.Format("<b> Static Thrust: </b>{0} kN (TWR {1}), {2}\n", (thrustASL).ToString("0.0##"), (thrustASL / weight).ToString("0.0##"), (throttleLocked ? "throttle locked" : "unthrottleable"));
+                    output += String.Format("<b> Static Thrust: </b>{0} (TWR {1}), {2}\n", Utilities.FormatThrust(thrustASL), (thrustASL / weight).ToString("0.0##"), (throttleLocked ? "throttle locked" : "unthrottleable"));
                 }
                 else
                 {
                     output += String.Format("{0}% min throttle\n", (minThrottle * 100f).ToString("N0"));
-                    output += String.Format("<b>Max. Static Thrust: </b>{0} kN (TWR {1})\n", (thrustASL).ToString("0.0##"), (thrustASL / weight).ToString("0.0##"));
-                    output += String.Format("<b>Min. Static Thrust: </b>{0} kN (TWR {1})\n", (thrustASL * minThrottle).ToString("0.0##"), (thrustASL * minThrottle / weight).ToString("0.0##"));
+                    output += String.Format("<b>Max. Static Thrust: </b>{0} (TWR {1})\n", Utilities.FormatThrust(thrustASL), (thrustASL / weight).ToString("0.0##"));
+                    output += String.Format("<b>Min. Static Thrust: </b>{0} (TWR {1})\n", Utilities.FormatThrust(thrustASL * minThrottle), (thrustASL * minThrottle / weight).ToString("0.0##"));
                 }
 
                 if (useVelCurve) // if thrust changes with mach
                 {
                     float vMin, vMax, tMin, tMax;
                     velCurve.FindMinMaxValue(out vMin, out vMax, out tMin, out tMax); // get the max mult, and thus report maximum thrust possible.
-                    output += String.Format("<b>Max. Thrust: </b>{0} kN at Mach {1} (TWR {2})\n", (thrustASL * vMax).ToString("0.0##"), tMax.ToString("0.#"), (thrustASL * vMax / weight).ToString("0.0##"));
+                    output += String.Format("<b>Max. Thrust: </b>{0} at Mach {1} (TWR {2})\n", Utilities.FormatThrust(thrustASL * vMax), tMax.ToString("0.#"), (thrustASL * vMax / weight).ToString("0.0##"));
                 }
             }
             else
@@ -571,12 +571,12 @@ namespace RealFuels
                     var suffix = throttleLocked ? "throttle locked" : "unthrottleable";
                     if (thrustASL != thrustVac)
                     {
-                        output += String.Format("<b>Thrust (Vac): </b>{0} kN (TWR {1}), {2}\n", (thrustVac).ToString("0.0##"), (thrustVac / weight).ToString("0.0##"), suffix);
-                        output += String.Format("<b>Thrust (ASL): </b>{0} kN (TWR {1}), {2}\n", (thrustASL).ToString("0.0##"), (thrustASL / weight).ToString("0.0##"), suffix);
+                        output += String.Format("<b>Thrust (Vac): </b>{0} (TWR {1}), {2}\n", Utilities.FormatThrust(thrustVac), (thrustVac / weight).ToString("0.0##"), suffix);
+                        output += String.Format("<b>Thrust (ASL): </b>{0} (TWR {1}), {2}\n", Utilities.FormatThrust(thrustASL), (thrustASL / weight).ToString("0.0##"), suffix);
                     }
                     else
                     {
-                        output += String.Format("<b>Thrust: </b>{0} kN (TWR {1}), {2}\n", (thrustVac).ToString("0.0##"), (thrustVac / weight).ToString("0.0##"), suffix);
+                        output += String.Format("<b>Thrust: </b>{0} (TWR {1}), {2}\n", Utilities.FormatThrust(thrustVac), (thrustVac / weight).ToString("0.0##"), suffix);
                     }
                 }
                 else
@@ -584,15 +584,15 @@ namespace RealFuels
                     output += String.Format("{0}% min throttle\n", (minThrottle * 100f).ToString("N0"));
                     if (thrustASL != thrustVac)
                     {
-                        output += String.Format("<b>Max. Thrust (Vac): </b>{0} kN (TWR {1})\n", (thrustVac).ToString("0.0##"), (thrustVac / weight).ToString("0.0##"));
-                        output += String.Format("<b>Max. Thrust (ASL): </b>{0} kN (TWR {1})\n", (thrustASL).ToString("0.0##"), (thrustASL / weight).ToString("0.0##"));
-                        output += String.Format("<b>Min. Thrust (Vac): </b>{0} kN (TWR {1})\n", (thrustVac * minThrottle).ToString("0.0##"), (thrustVac * minThrottle / weight).ToString("0.0##"));
-                        output += String.Format("<b>Min. Thrust (ASL): </b>{0} kN (TWR {1})\n", (thrustASL * minThrottle).ToString("0.0##"), (thrustASL * minThrottle / weight).ToString("0.0##"));
+                        output += String.Format("<b>Max. Thrust (Vac): </b>{0} (TWR {1})\n", Utilities.FormatThrust(thrustVac), (thrustVac / weight).ToString("0.0##"));
+                        output += String.Format("<b>Max. Thrust (ASL): </b>{0} (TWR {1})\n", Utilities.FormatThrust(thrustASL), (thrustASL / weight).ToString("0.0##"));
+                        output += String.Format("<b>Min. Thrust (Vac): </b>{0} (TWR {1})\n", Utilities.FormatThrust(thrustVac * minThrottle), (thrustVac * minThrottle / weight).ToString("0.0##"));
+                        output += String.Format("<b>Min. Thrust (ASL): </b>{0} (TWR {1})\n", Utilities.FormatThrust(thrustASL * minThrottle), (thrustASL * minThrottle / weight).ToString("0.0##"));
                     }
                     else
                     {
-                        output += String.Format("<b>Max. Thrust: </b>{0} kN (TWR {1})\n", (thrustVac).ToString("0.0##"), (thrustVac / weight).ToString("0.0##"));
-                        output += String.Format("<b>Min. Thrust: </b>{0} kN (TWR {1})\n", (thrustVac * minThrottle).ToString("0.0##"), (thrustVac * minThrottle / weight).ToString("0.0##"));
+                        output += String.Format("<b>Max. Thrust: </b>{0} (TWR {1})\n", Utilities.FormatThrust(thrustVac), (thrustVac / weight).ToString("0.0##"));
+                        output += String.Format("<b>Min. Thrust: </b>{0} (TWR {1})\n", Utilities.FormatThrust(thrustVac * minThrottle), (thrustVac * minThrottle / weight).ToString("0.0##"));
                     }
                 }
             }

--- a/Source/Utilities/Utilities.cs
+++ b/Source/Utilities/Utilities.cs
@@ -115,19 +115,19 @@ namespace RealFuels
         {
             if (thrust < 1e-6)
             {
-                return $"{thrust * 1e9:0.###} μN";
+                return $"{thrust * 1e9:0.#} μN";
             }
             if (thrust < 1e-3)
             {
-                return $"{thrust * 1e6:0.###} mN";
+                return $"{thrust * 1e6:0.#} mN";
             }
             else if (thrust < 1.0)
             {
-                return $"{thrust * 1e3:0.###} N";
+                return $"{thrust * 1e3:0.#} N";
             }
             else
             {
-                return $"{thrust:0.###} kN";
+                return $"{thrust:0.#} kN";
             }
         }
 

--- a/Source/Utilities/Utilities.cs
+++ b/Source/Utilities/Utilities.cs
@@ -72,7 +72,7 @@ namespace RealFuels
                 printStr += PrintNode(node, "");
             return printStr;
         }
-        
+
         public static string GetPartName(Part part)
         {
             if (part.partInfo != null)
@@ -109,6 +109,26 @@ namespace RealFuels
                 unit = "J";
             }
             return KSPUtil.PrintSI(flux * 1e3, unit, 4);
+        }
+
+        public static string FormatThrust(double thrust)
+        {
+            if (thrust < 1e-6)
+            {
+                return $"{thrust * 1e9:0.###} μN";
+            }
+            if (thrust < 1e-3)
+            {
+                return $"{thrust * 1e6:0.###} mN";
+            }
+            else if (thrust < 1.0)
+            {
+                return $"{thrust * 1e3:0.###} N";
+            }
+            else
+            {
+                return $"{thrust:0.###} kN";
+            }
         }
 
         #region Finding resources


### PR DESCRIPTION
This makes the module info and engine config info in the editor show more useful units and numbers rather than the default kN, which made comparing ion engines thrust almost impossible. It now shows varying units from kN to μN. Examples:
![image](https://user-images.githubusercontent.com/43384369/74887582-8ffc9780-537b-11ea-9aba-88f5fdba5d8b.png)
![image](https://user-images.githubusercontent.com/43384369/74887605-a276d100-537b-11ea-8463-cce5d3af8587.png)
![image](https://user-images.githubusercontent.com/43384369/74887640-bfab9f80-537b-11ea-8f25-288896643b7c.png)


