### PR TITLE
Preliminary mesh switching system

### DIFF
--- a/Source/Utilities/Utilities.cs
+++ b/Source/Utilities/Utilities.cs
@@ -161,6 +161,28 @@ namespace RealFuels
             }
         }
 
+        public static void updateAttachNode(AttachNode attachNode, Vector3 position)
+        {
+            Part attachedPart = attachNode.attachedPart;
+
+            if (attachedPart != null)
+            {
+                if (attachedPart != EditorLogic.RootPart)
+                {
+                    Vector3 offset = attachNode.owner.transform.TransformPoint(position) - attachNode.owner.transform.TransformPoint(attachNode.originalPosition);
+                    attachNode.attachedPart.transform.Translate(offset, Space.World);
+                }
+                else
+                {
+                    Vector3 offset = attachNode.owner.transform.TransformPoint(attachNode.originalPosition) - attachNode.owner.transform.TransformPoint(position);
+                    attachNode.owner.transform.Translate(offset, Space.World);
+                }
+            }
+
+            attachNode.position = position;
+            attachNode.originalPosition = position;
+        }
+
         #region Finding resources
         public static List<PartResource> FindResources(Part part, Propellant p)
         {


### PR DESCRIPTION
Implementing a simple version of a mesh switching system with node movement support

### Why?
While B9PartSwitch plays nicely with RealFuels, it isn't possible to restrict some model properties to predetermined `ModuleEngineConfigs` configs (e.g engine bells/nozzle increases/decreases Isp etc...).

### Changes
* Optional mesh switching node `MESH` in the `CONFIG` node from `ModuleEngineConfigs` Module:

```
CONFIG
{
    name = xyz
    MESH
    {
	transform = <transformName1>
	transform = <transformName2>
	....
	NODE
	{ 
	    node = <nodeName> // (e.g top)
	    position = <nodePosition> // (e.g 0.0, 5.2, 0.0)
	} 
    }
}
```




