### PR TITLE
Remove empty tank nodes from save file

### DIFF
--- a/Source/Tanks/FuelTankList.cs
+++ b/Source/Tanks/FuelTankList.cs
@@ -56,10 +56,19 @@ namespace RealFuels.Tanks
 
 		public void Save (ConfigNode node)
 		{
+			Save(node, true);
+		}
+
+		public void Save (ConfigNode node, bool includeEmpty)
+		{
 			foreach (FuelTank tank in this) {
-				ConfigNode tankNode = new ConfigNode ("TANK");
-				tank.Save (tankNode);
-				node.AddNode (tankNode);
+				// Don't spam save files with empty tank nodes, only save the relevant stuff
+				if (includeEmpty || tank.amount > 0 || tank.maxAmount > 0)
+				{
+					ConfigNode tankNode = new ConfigNode ("TANK");
+					tank.Save (tankNode);
+					node.AddNode (tankNode);
+				}
 			}
 		}
 

--- a/Source/Tanks/ModuleFuelTanks.cs
+++ b/Source/Tanks/ModuleFuelTanks.cs
@@ -436,7 +436,7 @@ namespace RealFuels.Tanks
 			}
 
 			node.AddValue ("volume", volume.ToString ("G17")); // no KSPField support for doubles
-			tankList.Save (node);
+			tankList.Save (node, false);
 		}
 
 		const int wait_frames = 2;

--- a/Source/Tanks/TankDefinition.cs
+++ b/Source/Tanks/TankDefinition.cs
@@ -70,7 +70,7 @@ namespace RealFuels.Tanks
 		public void Save (ConfigNode node)
 		{
 			ConfigNode.CreateConfigFromObject (this, node);
-			tankList.Save (node);
+			tankList.Save (node, true);
 		}
 
         public bool canHave


### PR DESCRIPTION
This removes empty tank nodes from craft and save files to reduce file sizes and load times.

Functionality is unaffected; any missing nodes are populated with defaults when the tank list is loaded.