### PR TITLE
Display Ullage Status When Pressure-Fed

### DIFF
--- a/Source/Engines/ModuleEnginesRF.cs
+++ b/Source/Engines/ModuleEnginesRF.cs
@@ -292,14 +292,14 @@ namespace RealFuels
             if (HighLogic.LoadedSceneIsEditor && pressureFed)
                 ullageSet.EditorPressurized();
 
-            if (pressureFed)
-                propellantStatus = ullageSet.PressureOK() ? "Feed pressure OK" : "<color=red>Needs high pressure tanks</color>";
+            if (pressureFed && !ullageSet.PressureOK())
+                propellantStatus = "<color=red>Needs high pressure tanks</color>";
             else if (HighLogic.LoadedSceneIsFlight && ullage && RFSettings.Instance.simulateUllage)
             {
                 propellantStatus = ullageSet.GetUllageState(out Color ullageColor);
                 part.stackIcon.SetIconColor(ullageColor);
             } else
-                propellantStatus = "Nominal";
+                propellantStatus = pressureFed ? "Feed pressure OK" : "Nominal";
         }
 
         public virtual void CalcThrottleResponseRate(ref float responseRate, ref bool instant)


### PR DESCRIPTION
Pressure-fed engines were only displaying the pressurization state, even if they required ullage.  Fix prioritization to show error case (insufficient pressure), then ullage state if applicable, then non-error cases.

Please squash+merge and fix the typo in the commit.