### PR TITLE
Add optional B9PartSwitch integration

### DIFF
--- a/Source/Engines/ModuleEngineConfigs.cs
+++ b/Source/Engines/ModuleEngineConfigs.cs
@@ -176,8 +176,8 @@ namespace RealFuels
         private static MethodInfo B9PS_SwitchSubtype;
         private void InitializeB9PSReflection()
         {
-            B9PS_SwitchSubtype = Type.GetType("B9PartSwitch.ModuleB9PartSwitch, B9PartSwitch")?.GetMethod("SwitchSubtype");
             B9PS_moduleID = Type.GetType("B9PartSwitch.CustomPartModule, B9PartSwitch")?.GetField("moduleID");
+            B9PS_SwitchSubtype = Type.GetType("B9PartSwitch.ModuleB9PartSwitch, B9PartSwitch")?.GetMethod("SwitchSubtype");
             _b9psReflectionInitialized = true;
         }
 
@@ -211,7 +211,7 @@ namespace RealFuels
                         B9PS_SwitchSubtype?.Invoke(module, new object[] { subtypeName });
                 }
                 else
-                    Debug.LogError($"*RFMEC* {part} has B9PS integration enabled, but the ({configuration}) configuration does not specify a `b9psSubtypeName`!");
+                    Debug.LogError($"*RFMEC* {part} has B9PS integration enabled, but the {configuration} configuration does not specify a `b9psSubtypeName`!");
             }
         }
         #endregion

--- a/Source/Engines/ModuleEngineConfigs.cs
+++ b/Source/Engines/ModuleEngineConfigs.cs
@@ -207,6 +207,9 @@ namespace RealFuels
                 var b9psSubtypeSelector = module.Fields["currentSubtypeIndex"];
                 b9psSubtypeSelector.guiActive = false;
                 b9psSubtypeSelector.guiActiveEditor = false;
+                var b9psShowSelectorWindow = module.Events["ShowSubtypesWindow"];
+                b9psShowSelectorWindow.guiActive = false;
+                b9psShowSelectorWindow.guiActiveEditor = false;
             }
         }
 

--- a/Source/Engines/ModuleEngineConfigs.cs
+++ b/Source/Engines/ModuleEngineConfigs.cs
@@ -319,11 +319,11 @@ namespace RealFuels
             if (HighLogic.LoadedSceneIsEditor)
                 GameEvents.onPartActionUIDismiss.Add(OnPartActionGuiDismiss);
 
+            InitializeB9PSIntegrationIfEnabled();
+
             ConfigSaveLoad();
 
             SetConfiguration();
-
-            InitializeB9PSIntegrationIfEnabled();
 
             // Why is this here, if KSP will call this normally?
             part.Modules.GetModule("ModuleEngineIgnitor")?.OnStart(state);

--- a/Source/Engines/ModuleEngineConfigs.cs
+++ b/Source/Engines/ModuleEngineConfigs.cs
@@ -199,29 +199,28 @@ namespace RealFuels
         {
             // Hide the GUI for the `ModuleB9PartSwitch` managed by RF.
             // This is somewhat of a hack-ish solution...
-            if (B9PSModule is PartModule module)
+            if (B9PSModule is PartModule)
             {
-                var b9psSubtypeTitle = module.Fields["currentSubtypeTitle"];
-                b9psSubtypeTitle.guiActive = false;
-                b9psSubtypeTitle.guiActiveEditor = false;
-                var b9psSubtypeSelector = module.Fields["currentSubtypeIndex"];
-                b9psSubtypeSelector.guiActive = false;
-                b9psSubtypeSelector.guiActiveEditor = false;
-                var b9psShowSelectorWindow = module.Events["ShowSubtypesWindow"];
-                b9psShowSelectorWindow.guiActive = false;
-                b9psShowSelectorWindow.guiActiveEditor = false;
+                B9PSModule.Fields["currentSubtypeTitle"].guiActive = false;
+                B9PSModule.Fields["currentSubtypeTitle"].guiActiveEditor = false;
+                B9PSModule.Fields["currentSubtypeIndex"].guiActive = false;
+                B9PSModule.Fields["currentSubtypeIndex"].guiActiveEditor = false;
+                B9PSModule.Events["ShowSubtypesWindow"].guiActive = false;
+                B9PSModule.Events["ShowSubtypesWindow"].guiActiveEditor = false;
             }
         }
 
         public void UpdateB9PSVariant()
         {
-            if (B9PSModule is PartModule module)
+            if (B9PSModule is PartModule)
             {
                 string subtypeName = string.Empty;
-                if (config.TryGetValue("b9psSubtypeName", ref subtypeName))
-                    B9PS_SwitchSubtype?.Invoke(module, new object[] { subtypeName });
-                else
-                    Debug.LogError($"*RFMEC* {part} has B9PS integration enabled, but the {configuration} configuration does not specify a `b9psSubtypeName`!");
+                if (!config.TryGetValue("b9psSubtypeName", ref subtypeName))
+                {
+                    subtypeName = configuration;
+                    Debug.LogWarning($"*RFMEC* {part} does not specify b9psSubtypeName in current config {configuration}; defaulting to \"{subtypeName}\" for B9PS switching.");
+                }
+                B9PS_SwitchSubtype?.Invoke(B9PSModule, new object[] { subtypeName });
             }
         }
         #endregion
@@ -331,8 +330,6 @@ namespace RealFuels
 
         public override void OnStartFinished(StartState state)
         {
-            base.OnStartFinished(state);
-
             HideB9PSVariantSelector();  // Just the one managed by RF, if there is one.
         }
         #endregion

--- a/Source/Engines/ModuleEngineConfigs.cs
+++ b/Source/Engines/ModuleEngineConfigs.cs
@@ -174,7 +174,7 @@ namespace RealFuels
         private static bool _b9psReflectionInitialized = false;
         private static FieldInfo B9PS_moduleID;
         private static MethodInfo B9PS_SwitchSubtype;
-        public void InitializeB9PSReflection()
+        private void InitializeB9PSReflection()
         {
             B9PS_SwitchSubtype = Type.GetType("B9PartSwitch.ModuleB9PartSwitch, B9PartSwitch")?.GetMethod("SwitchSubtype");
             B9PS_moduleID = Type.GetType("B9PartSwitch.CustomPartModule, B9PartSwitch")?.GetField("moduleID");

--- a/Source/Engines/ModuleEngineConfigs.cs
+++ b/Source/Engines/ModuleEngineConfigs.cs
@@ -195,6 +195,21 @@ namespace RealFuels
             }
         }
 
+        private void HideB9PSVariantSelector()
+        {
+            // Hide the GUI for the `ModuleB9PartSwitch` managed by RF.
+            // This is somewhat of a hack-ish solution...
+            if (B9PSModule is PartModule module)
+            {
+                var b9psSubtypeTitle = module.Fields["currentSubtypeTitle"];
+                b9psSubtypeTitle.guiActive = false;
+                b9psSubtypeTitle.guiActiveEditor = false;
+                var b9psSubtypeSelector = module.Fields["currentSubtypeIndex"];
+                b9psSubtypeSelector.guiActive = false;
+                b9psSubtypeSelector.guiActiveEditor = false;
+            }
+        }
+
         public void UpdateB9PSVariant()
         {
             if (B9PSModule is PartModule module)
@@ -315,17 +330,7 @@ namespace RealFuels
         {
             base.OnStartFinished(state);
 
-            // Hide the GUI for the `ModuleB9PartSwitch` managed by RF.
-            // This is somewhat of a hack-ish solution...
-            if (B9PSModule is PartModule module)
-            {
-                var b9psSubtypeTitle = module.Fields["currentSubtypeTitle"];
-                var b9psSubtypeSelector = module.Fields["currentSubtypeIndex"];
-                b9psSubtypeTitle.guiActive = false;
-                b9psSubtypeTitle.guiActiveEditor = false;
-                b9psSubtypeSelector.guiActive = false;
-                b9psSubtypeSelector.guiActiveEditor = false;
-            }
+            HideB9PSVariantSelector();  // Just the one managed by RF, if there is one.
         }
         #endregion
 

--- a/Source/Engines/ModuleEngineConfigs.cs
+++ b/Source/Engines/ModuleEngineConfigs.cs
@@ -172,8 +172,8 @@ namespace RealFuels
 
         #region B9PartSwitch
         private static bool _b9psReflectionInitialized = false;
-        private static FieldInfo B9PSModuleID;
-        private static MethodInfo B9PSSwitchSubtype;
+        private static FieldInfo B9PS_moduleID;
+        private static MethodInfo B9PS_SwitchSubtype;
 
         public void UpdateB9PSVariant()
         {
@@ -181,26 +181,26 @@ namespace RealFuels
             {
                 if (!_b9psReflectionInitialized)
                 {
-                    B9PSSwitchSubtype = Type.GetType("B9PartSwitch.ModuleB9PartSwitch, B9PartSwitch")?.GetMethod("SwitchSubtype");
-                    B9PSModuleID = Type.GetType("B9PartSwitch.CustomPartModule, B9PartSwitch")?.GetField("moduleID");
+                    B9PS_SwitchSubtype = Type.GetType("B9PartSwitch.ModuleB9PartSwitch, B9PartSwitch")?.GetMethod("SwitchSubtype");
+                    B9PS_moduleID = Type.GetType("B9PartSwitch.CustomPartModule, B9PartSwitch")?.GetField("moduleID");
                     _b9psReflectionInitialized = true;
                 }
 
                 if (b9psModuleID != string.Empty)
                 {
                     string subtypeName = string.Empty;
-                    var enabledConfig = configs.FirstOrDefault(c => c.GetValue("name").Equals(configuration));
-
-                    if (enabledConfig != null && enabledConfig.TryGetValue("b9psSubtypeName", ref subtypeName))
+                    if (config.TryGetValue("b9psSubtypeName", ref subtypeName))
                     {
                         var b9psModule = GetSpecifiedModules(part, string.Empty, -1, "ModuleB9PartSwitch", false)
-                            .Find(m => ((string)B9PSModuleID.GetValue(m)).Equals(b9psModuleID));
+                            .FirstOrDefault(m => ((string)B9PS_moduleID.GetValue(m)).Equals(b9psModuleID));
 
                         if (b9psModule != null)
-                            B9PSSwitchSubtype.Invoke(b9psModule, new object[] { subtypeName });
+                            B9PS_SwitchSubtype.Invoke(b9psModule, new object[] { subtypeName });
                         else
                             Debug.LogError($"*RFMEC* B9PartSwitch module with ID {b9psModuleID} was not found for {part}!");
                     }
+                    else
+                        Debug.LogError($"*RFMEC* {part} has B9PS integration enabled, but the ({configuration}) configuration does not specify a `b9psSubtypeName`!");
                 }
             }
         }

--- a/Source/Utilities/Utilities.cs
+++ b/Source/Utilities/Utilities.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Reflection;
 using System.Collections.Generic;
 using System.Linq;
@@ -38,6 +38,21 @@ namespace RealFuels
                 return _kerbalismFound.Value;
             }
         }
+
+        private static bool? _b9psFound = null;
+        public static bool B9PSFound
+        {
+            get
+            {
+                if (!_b9psFound.HasValue)
+                {
+                    var assembly = AssemblyLoader.loadedAssemblies.FirstOrDefault(a => a.assembly.GetName().Name == "B9PartSwitch")?.assembly;
+                    _b9psFound = (assembly is Assembly);
+                }
+                return _b9psFound.Value;
+            }
+        }
+
         public static FloatCurve Mod(FloatCurve fc, float sMult, float vMult)
         {
             FloatCurve newCurve = new FloatCurve();


### PR DESCRIPTION
This patch adds optional B9PartSwitch integration for RealFuels, in the form of automatic variant switching based on engine config. It is entirely optional and does not have any effect if B9PartSwitch is not installed.

Parts can opt-in to B9PS integration by adding the `b9psModuleID` key to its `ModuleEngineConfigs`. If so, each `CONFIG` must have a `b9psSubtypeName` key, indicating the B9PS subtype that should be used for that particular variant. RealFuels will then access the specified B9PS module via reflection and set the subtype accordingly, if B9PS is installed. The selector UI for that particular B9PS module will be disabled, as it is managed by RealFuels.

The primary use-case for this integration is to enable switching of Waterfall plumes based on engine configuration. In "stock" setups, switching is done through one of two methods:

* For multi-mode engines, each mode uses a separate `ModuleEngines`. One `ModuleWaterfallFX` (roughly corresponding to a RealPlume `PLUME`) is thus created for each engine module. The Waterfall modules targeting inactive modes are deactivated by way of seeing a zero for the throttle of that particular engine module.
* B9PS can be used where there is only one `ModuleEngines`. In this case, B9's experimental module switching feature is used to dynamically switch out `TEMPLATE`s (perhaps corresponding to `MODEL_MULTI_SHURIKEN_PERSIST`s generated by RealPlume) inside the corresponding Waterfall module. In practice, B9PS handles model and fuel switching too -- this is used in ex. BDB.

Neither of these are workable for RealFuels-based engines. Thus, the approach taken here: Have RF manage fuel switching as usual, but outsource the complicated module switching to B9PS in a way that's transparent to the user.

Many, many thanks to @DRVeyl for guiding me through writing this patch.