### PR TITLE
Extend B9PS integration to support switching of multiple modules

### DIFF
--- a/Source/Engines/ModuleEngineConfigs.cs
+++ b/Source/Engines/ModuleEngineConfigs.cs
@@ -168,9 +168,9 @@ namespace RealFuels
         #endregion
 
         #region B9PartSwitch
-        private static bool _b9psReflectionInitialized = false;
-        private static FieldInfo B9PS_moduleID;
-        private static MethodInfo B9PS_SwitchSubtype;
+        protected static bool _b9psReflectionInitialized = false;
+        protected static FieldInfo B9PS_moduleID;
+        protected static MethodInfo B9PS_SwitchSubtype;
         public List<string> B9PSModuleIDs;
         public Dictionary<string, PartModule> B9PSModules;
 
@@ -252,8 +252,7 @@ namespace RealFuels
                 string moduleID = entry.Key;
                 PartModule module = entry.Value;
 
-                string subtypeName;
-                if (!subtypeSpecifications.TryGetValue(moduleID, out subtypeName))
+                if (!subtypeSpecifications.TryGetValue(moduleID, out string subtypeName))
                 {
                     Debug.LogError($"*RFMEC* {part} does not specify b9psSubtype name in current config {configuration} for B9PS module with ID {moduleID}; defaulting to `{configuration}`.");
                     subtypeName = configuration;

--- a/Source/Engines/ModuleEngineConfigs.cs
+++ b/Source/Engines/ModuleEngineConfigs.cs
@@ -252,12 +252,8 @@ namespace RealFuels
                 string moduleID = entry.Key;
                 PartModule module = entry.Value;
 
-                var subtypeName = subtypeSpecifications
-                    .Where(kv => kv.Key == moduleID)
-                    .Select(kv => kv.Value)
-                    .FirstOrDefault();
-
-                if (subtypeName == null)
+                string subtypeName;
+                if (!subtypeSpecifications.TryGetValue(moduleID, out subtypeName))
                 {
                     Debug.LogError($"*RFMEC* {part} does not specify b9psSubtype name in current config {configuration} for B9PS module with ID {moduleID}; defaulting to `{configuration}`.");
                     subtypeName = configuration;


### PR DESCRIPTION
This way, ex. plume and model switching could be implemented separately.

The modules and subtypes are now defined in `CONFIG`s, using `LinkB9PSModule` _nodes_. The node contains 2 keys, `name` and `subtype`. The presence of a single `Link` node with a given `name` signifies that RF should be managing the corresponding module, so _all_ configs must specify a subtype for that module.

This is not backwards-compatible with the original PR, but I doubt anyone will be broken by it.

Example:

```text
@MODULE[ModuleEngineConfigs]
{
    @CONFIG[blah]
    {
        %LinkB9PSModule[SwitcherA] { subtype = foo }
        %LinkB9PSModule[SwitcherB] { subtype = bar }
    }
    // Etc. for other configs.
}
```

cc @DRVeyl -- thanks for the help!