### PR TITLE
Introduce `ModuleAnimatedBimodalEngine`

### DIFF
--- a/Source/Engines/ModuleAnimatedBimodalEngine.cs
+++ b/Source/Engines/ModuleAnimatedBimodalEngine.cs
@@ -125,6 +125,7 @@ namespace RealFuels
                     Debug.LogWarning($"*RFMEC* {part} has unpaired config `{badConfig.GetValue("name")}`; removing!");
                     configs.Remove(badConfig);
                 }
+                OverwriteSavedConfigs();
                 SetConfiguration();
             }
         }

--- a/Source/Engines/ModuleAnimatedBimodalEngine.cs
+++ b/Source/Engines/ModuleAnimatedBimodalEngine.cs
@@ -1,0 +1,262 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using UnityEngine;
+using Debug = UnityEngine.Debug;
+
+namespace RealFuels
+{
+    internal class BidirectionalDictionary<TForward, TReverse>
+    {
+        private Dictionary<TForward, TReverse> _forward;
+        private Dictionary<TReverse, TForward> _reverse;
+
+        public Indexer<TForward, TReverse> Fwd { get => new Indexer<TForward, TReverse>(ref _forward, ref _reverse); }
+        public Indexer<TReverse, TForward> Rev { get => new Indexer<TReverse, TForward>(ref _reverse, ref _forward); }
+
+        internal class Indexer<TKey, TValue> : IEnumerable<KeyValuePair<TKey, TValue>>, IEnumerable
+        {
+            private Dictionary<TKey, TValue> _fwd;
+            private Dictionary<TValue, TKey> _rev;
+
+            public TValue this[TKey key]
+            {
+                get => _fwd[key];
+                set
+                {
+                    _fwd[key] = value;
+                    _rev[value] = key;
+                }
+            }
+
+            public IEnumerator<KeyValuePair<TKey, TValue>> GetEnumerator() => _fwd.GetEnumerator();
+            IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+
+            public ICollection<TKey> Keys { get => _fwd.Keys; }
+
+            public bool ContainsKey(TKey key) => _fwd.ContainsKey(key);
+
+            public Indexer(ref Dictionary<TKey, TValue> forward, ref Dictionary<TValue, TKey> reverse)
+            {
+                _fwd = forward;
+                _rev = reverse;
+            }
+        }
+
+        public int Count { get => _forward.Count; }
+
+        public void Add(TForward x, TReverse y)
+        {
+            _forward.Add(x, y);
+            _reverse.Add(y, x);
+        }
+
+        public BidirectionalDictionary()
+        {
+            _forward = new Dictionary<TForward, TReverse>();
+            _reverse = new Dictionary<TReverse, TForward>();
+        }
+    }
+
+    public class ModuleAnimatedBimodalEngine : ModuleEngineConfigs
+    {
+        private enum State { Primary, Secondary, Unpaired }
+        private enum AnimPosition { Begin, End, Forward, Reverse }
+
+        [KSPField]
+        public string animationName = String.Empty;
+        [KSPField]
+        public string toPrimaryText = "Retract Nozzle";
+        [KSPField]
+        public string toSecondaryText = "Deploy Nozzle";
+        [KSPField]
+        public bool shutdownWhileSwitching = false;
+
+        private BidirectionalDictionary<string, string> configPairs;  // (primary, secondary)
+        private State state;
+        private ModuleEngines activeEngine;
+
+        private List<AnimationState> animationStates;
+        private AnimPosition animTarget;
+
+        private void LoadConfigPairs()
+        {
+            configPairs = new BidirectionalDictionary<string, string>();
+
+            // Consider all configs `secondaryConfig` declared to be "primary".
+            foreach (var primaryCfg in configs.Where(c => c.HasValue("secondaryConfig")))
+            {
+                string primaryName = primaryCfg.GetValue("name");
+                string secondaryName = primaryCfg.GetValue("secondaryConfig");
+
+                // Look for the secondary config it specifies.
+                if (!(configs.Find(c => c.GetValue("name") == secondaryName) is ConfigNode secondaryCfg))
+                {
+                    Debug.LogError($"*RFMEC* Config `{primaryName}` of {part} specifies a nonexistent secondaryConfig `{secondaryName}`!");
+                    continue;
+                }
+
+                // Check if the primary config already exists.
+                if (configPairs.Fwd.ContainsKey(primaryName))
+                    Debug.LogError($"*RFMEC* {part} has multiple configs of the same name: `{primaryName}`!");
+                // Check if the secondary config has already been claimed by another primary config.
+                else if (configPairs.Rev.ContainsKey(secondaryName))
+                    Debug.LogError($"*RFMEC* Config `{primaryName}` of {part} specifies `{secondaryName}` as its secondary config, but this config has already been declared as the secondary config of `{configPairs.Rev[primaryName]}`!");
+                // Check if the primary config is the *secondary* config of another config.
+                else if (configPairs.Rev.ContainsKey(primaryName))
+                    Debug.LogError($"*RFMEC* Config `{primaryName}` declares an secondaryConfig itself, but it has already been specified to be the secondary of config `{configPairs.Rev[primaryName]}`!");
+                else
+                    configPairs.Add(primaryName, secondaryName);
+            }
+
+            // Dump all the unmatched configs to log.
+            if (configPairs.Count * 2 != configs.Count)
+            {
+                configs
+                    .Select(c => c.GetValue("name"))
+                    .Where(c => !(configPairs.Fwd.ContainsKey(c) || configPairs.Rev.ContainsKey(c)))
+                    .ToList()
+                    .ForEach(c => Debug.LogError($"*RFMEC* {part} has unpaired config `{c}`!"));
+            }
+        }
+
+        private void LoadAnimations()
+        {
+            // Adapted from https://github.com/post-kerbin-mining-corporation/DeployableEngines/blob/5cd045e1b2f65cf758b510c267af0c1dfb8c0502/Source/DeployableEngines/ModuleDeployableEngine.cs#L166
+            if (string.IsNullOrEmpty(animationName)) return;
+
+            animationStates = new List<AnimationState>();
+            foreach (var anim in part.FindModelAnimators(animationName))
+            {
+                var animState = anim[animationName];
+                animState.speed = 0;
+                animState.enabled = true;
+                animState.wrapMode = WrapMode.ClampForever;
+                anim.Blend(animationName);
+                animationStates.Add(animState);
+            }
+        }
+
+        public override void OnStart(StartState state)
+        {
+            ConfigSaveLoad();
+            LoadConfigPairs();
+            LoadAnimations();
+            base.OnStart(state);
+            ForceAnimationTarget();
+
+            activeEngine = GetSpecifiedModule(part, engineID, moduleIndex, type, useWeakType) as ModuleEngines;
+        }
+
+        public override void OnUpdate()
+        {
+            base.OnUpdate();
+
+            if (state == State.Unpaired || animationStates == null) return;
+
+            foreach (var animState in animationStates)
+            {
+                if (animState.normalizedTime >= 1f && animTarget == AnimPosition.Forward)
+                {
+                    animTarget = AnimPosition.End;
+                    UpdateAnimationSpeed();
+                    break;
+                }
+                if (animState.normalizedTime <= 0f && animTarget == AnimPosition.Reverse)
+                {
+                    animTarget = AnimPosition.Begin;
+                    UpdateAnimationSpeed();
+                    break;
+                }
+            }
+        }
+
+        public override void SetConfiguration(string newConfiguration = null, bool resetTechLevels = false)
+        {
+            var oldState = state;
+            base.SetConfiguration(newConfiguration, resetTechLevels);
+
+            if (configPairs == null) return;
+
+            if (configPairs.Fwd.ContainsKey(configuration))
+            {
+                state = State.Primary;
+                Events["ToggleMode"].guiActive = true;
+                Events["ToggleMode"].guiActiveEditor = true;
+                Events["ToggleMode"].guiName = toSecondaryText;
+            }
+            else if (configPairs.Rev.ContainsKey(configuration))
+            {
+                state = State.Secondary;
+                Events["ToggleMode"].guiActive = true;
+                Events["ToggleMode"].guiActiveEditor = true;
+                Events["ToggleMode"].guiName = toPrimaryText;
+            }
+            else
+            {
+                state = State.Unpaired;
+                Events["ToggleMode"].guiActive = false;
+                Events["ToggleMode"].guiActiveEditor = false;
+            }
+
+            UpdateAnimationTarget(oldState);
+        }
+
+        [KSPEvent(guiActive = true, guiActiveEditor = true)]
+        public void ToggleMode()
+        {
+            if (state == State.Unpaired) return;
+
+            bool wasIgnited = activeEngine.getIgnitionState;
+            if (shutdownWhileSwitching) activeEngine.EngineIgnited = false;
+
+            var targetConfig = state == State.Primary ? configPairs.Fwd[configuration] : configPairs.Rev[configuration];
+            SetConfiguration(targetConfig);
+
+            if (wasIgnited && shutdownWhileSwitching)
+                activeEngine.Actions["ActivateAction"].Invoke(new KSPActionParam(KSPActionGroup.None, KSPActionType.Activate));
+        }
+
+        private void ForceAnimationTarget()
+        {
+            if (state == State.Unpaired || animationStates == null) return;
+            foreach (var animState in animationStates)
+            {
+                animState.normalizedTime = state == State.Primary ? 0f : 1f;
+                animState.speed = 0f;
+                animTarget = state == State.Primary ? AnimPosition.Begin : AnimPosition.End;
+            }
+        }
+
+        private void UpdateAnimationTarget(State oldState)
+        {
+            if (state == State.Unpaired || animationStates == null) return;
+
+            if (HighLogic.LoadedSceneIsEditor)
+            {
+                ForceAnimationTarget();
+                return;
+            }
+            if (oldState == State.Primary && state == State.Secondary)
+                animTarget = AnimPosition.Forward;
+            if (oldState == State.Secondary && state == State.Primary)
+                animTarget = AnimPosition.Reverse;
+            if (oldState == State.Unpaired && state != State.Unpaired)
+                ForceAnimationTarget();
+
+            UpdateAnimationSpeed();
+        }
+
+        private void UpdateAnimationSpeed()
+        {
+            if (animationStates == null) return;
+            foreach (var animState in animationStates)
+            {
+                if (animTarget == AnimPosition.Forward) animState.speed = 1f;
+                else if (animTarget == AnimPosition.Reverse) animState.speed = -1f;
+                else animState.speed = 0f;
+            }
+        }
+    }
+}

--- a/Source/Engines/ModuleAnimatedBimodalEngine.cs
+++ b/Source/Engines/ModuleAnimatedBimodalEngine.cs
@@ -158,6 +158,9 @@ namespace RealFuels
                 : toTargetText;
         }
 
+        [KSPAction("Toggle Engine Mode")]
+        public void ToggleAction(KSPActionParam _) => ToggleMode();
+
         [KSPEvent(guiActive = true, guiActiveEditor = true)]
         public void ToggleMode()
         {
@@ -167,7 +170,16 @@ namespace RealFuels
             float oldFuelFlow = activeEngine.maxFuelFlow;
 
             SetConfiguration(GetPairedConfig(configuration));
+            UpdateSymmetryCounterparts();
 
+            StartToggleCoroutines(oldAtmCurve, oldFuelFlow);
+            DoForEachSymmetryCounterpart(
+                (eng) => (eng as ModuleAnimatedBimodalEngine).StartToggleCoroutines(oldAtmCurve, oldFuelFlow)
+            );
+        }
+
+        private void StartToggleCoroutines(FloatCurve oldAtmCurve, float oldFuelFlow)
+        {
             if (HighLogic.LoadedSceneIsFlight && activeEngine.getIgnitionState)
             {
                 StartCoroutine(TemporarilyRemoveSpoolUp());
@@ -177,9 +189,6 @@ namespace RealFuels
                 if (thrustLerpTime > 0f) StartCoroutine(LerpThrust(oldAtmCurve, oldFuelFlow));
             }
         }
-
-        [KSPAction("Toggle Engine Mode")]
-        public void ToggleAction(KSPActionParam _) => ToggleMode();
 
         private IEnumerator TemporarilyRemoveSpoolUp()
         {
@@ -404,7 +413,6 @@ namespace RealFuels
             if (GUILayout.Button(new GUIContent(GetToggleText(configuration))))
             {
                 ToggleMode();
-                UpdateSymmetryCounterparts();
                 MarkWindowDirty();
             }
             GUILayout.EndHorizontal();

--- a/Source/Engines/ModuleAnimatedBimodalEngine.cs
+++ b/Source/Engines/ModuleAnimatedBimodalEngine.cs
@@ -61,13 +61,13 @@ namespace RealFuels
         [KSPField]
         public string animationName = string.Empty;
         [KSPField]
-        public string primaryDescription = "retracted";
+        public string primaryDescription = "primary";
         [KSPField]
-        public string secondaryDescription = "extended";
+        public string secondaryDescription = "secondary";
         [KSPField]
-        public string toPrimaryText = "Retract Nozzle";
+        public string toPrimaryText = string.Empty;
         [KSPField]
-        public string toSecondaryText = "Extend Nozzle";
+        public string toSecondaryText = string.Empty;
         #endregion
 
 
@@ -149,7 +149,10 @@ namespace RealFuels
 
         public string GetToggleText(string configName)
         {
-            return GetMode(configName) == Mode.Primary ? toSecondaryText : toPrimaryText;
+            var toTargetText = GetMode(configName) == Mode.Primary ? toSecondaryText : toPrimaryText;
+            return string.IsNullOrEmpty(toTargetText)
+                ? $"Switch to {GetModeDescription(GetPairedConfig(configName))} mode"
+                : toTargetText;
         }
 
         [KSPEvent(guiActive = true, guiActiveEditor = true)]

--- a/Source/Engines/ModuleAnimatedBimodalEngine.cs
+++ b/Source/Engines/ModuleAnimatedBimodalEngine.cs
@@ -113,7 +113,7 @@ namespace RealFuels
                     .Select(c => c.GetValue("name"))
                     .Where(c => !(configPairs.Fwd.ContainsKey(c) || configPairs.Rev.ContainsKey(c)))
                     .ToList()
-                    .ForEach(c => Debug.LogError($"*RFMEC* {part} has unpaired config `{c}`!"));
+                    .ForEach(c => Debug.LogWarning($"*RFMEC* {part} has unpaired config `{c}`!"));
             }
         }
 

--- a/Source/Engines/ModuleAnimatedBimodalEngine.cs
+++ b/Source/Engines/ModuleAnimatedBimodalEngine.cs
@@ -346,10 +346,11 @@ namespace RealFuels
             {
                 ConfigNode primaryCfg = GetConfigByName(primaryCfgName);
                 string secondaryCfgName = configPairs.Fwd[primaryCfgName];
+                ConfigNode secondaryCfg = GetConfigByName(secondaryCfgName);
 
                 string displayName = primaryCfgName;
 
-                ConfigNode targetCfg = mode == Mode.Primary ? primaryCfg : GetConfigByName(secondaryCfgName);
+                ConfigNode targetCfg = mode == Mode.Primary ? primaryCfg : secondaryCfg;
                 string targetCfgName = targetCfg.GetValue("name");
 
                 GUILayout.BeginHorizontal();
@@ -366,6 +367,11 @@ namespace RealFuels
                     {
                         if (UnlockedConfig(primaryCfg, part))
                         {
+                            if (!UnlockedConfig(secondaryCfg, part))
+                            {
+                                EntryCostDatabase.SetUnlocked(secondaryCfgName);
+                                EntryCostDatabase.UpdatePartEntryCosts();
+                            }
                             if (GUILayout.Button(new GUIContent($"Switch to {displayName}{costString}", GetConfigInfo(targetCfg))))
                             {
                                 SetConfiguration(displayName, true);
@@ -373,7 +379,6 @@ namespace RealFuels
                                 MarkWindowDirty();
                             }
                         }
-
                         else
                         {
                             double upgradeCost = EntryCostManager.Instance.ConfigEntryCost(primaryCfgName);

--- a/Source/Engines/ModuleEngineConfigs.cs
+++ b/Source/Engines/ModuleEngineConfigs.cs
@@ -427,7 +427,7 @@ namespace RealFuels
             return info;
         }
 
-        public string GetConfigInfo(ConfigNode config, bool addDescription = true, bool colorName = false)
+        virtual public string GetConfigInfo(ConfigNode config, bool addDescription = true, bool colorName = false)
         {
             TechLevel cTL = new TechLevel();
             if (!cTL.Load(config, techNodes, engineType, techLevel))

--- a/Source/Engines/ModuleEngineConfigs.cs
+++ b/Source/Engines/ModuleEngineConfigs.cs
@@ -11,6 +11,8 @@ namespace RealFuels
 {
     public class ModuleHybridEngine : ModuleEngineConfigs
     {
+        public override string GUIButtonName => "Multi-Mode Engine";
+        public override string EditorDescription => "Select a default configuration. All configurations can be cycled through in-flight.";
         ModuleEngines ActiveEngine = null;
 
         public override void OnLoad(ConfigNode node)
@@ -355,6 +357,8 @@ namespace RealFuels
             LoadB9PSModules();
 
             SetConfiguration();
+
+            Fields[nameof(showRFGUI)].guiName = GUIButtonName;
 
             // Why is this here, if KSP will call this normally?
             part.Modules.GetModule("ModuleEngineIgnitor")?.OnStart(state);
@@ -1074,6 +1078,8 @@ namespace RealFuels
         #endregion
 
         #region GUI
+        public virtual string GUIButtonName => "Engine";
+        public virtual string EditorDescription => "Select a configuration for this engine.";
         [KSPField(guiActiveEditor = true, guiName = "Engine", groupName = groupName),
          UI_Toggle(enabledText = "Hide GUI", disabledText = "Show GUI")]
         [NonSerialized]
@@ -1168,6 +1174,9 @@ namespace RealFuels
         private void EngineManagerGUI(int WindowID)
         {
             GUILayout.Space(20);
+            GUILayout.BeginHorizontal();
+            GUILayout.Label(EditorDescription);
+            GUILayout.EndHorizontal();
             foreach (ConfigNode node in configs)
             {
                 string nName = node.GetValue("name");

--- a/Source/Engines/ModuleEngineConfigs.cs
+++ b/Source/Engines/ModuleEngineConfigs.cs
@@ -1171,13 +1171,15 @@ namespace RealFuels
             }
         }
 
+        virtual protected IEnumerable<ConfigNode> GetGUIVisibleConfigs() => configs;
+
         private void EngineManagerGUI(int WindowID)
         {
             GUILayout.Space(20);
             GUILayout.BeginHorizontal();
             GUILayout.Label(EditorDescription);
             GUILayout.EndHorizontal();
-            foreach (ConfigNode node in configs)
+            foreach (ConfigNode node in GetGUIVisibleConfigs())
             {
                 string nName = node.GetValue("name");
                 GUILayout.BeginHorizontal();

--- a/Source/Engines/ModuleEngineConfigs.cs
+++ b/Source/Engines/ModuleEngineConfigs.cs
@@ -12,7 +12,7 @@ namespace RealFuels
     public class ModuleHybridEngine : ModuleEngineConfigs
     {
         public override string GUIButtonName => "Multi-Mode Engine";
-        public override string EditorDescription => "Select a default configuration. All configurations can be cycled through in-flight.";
+        public override string EditorDescription => "Select a default configuration. You can cycle through all other configurations in flight.";
         ModuleEngines ActiveEngine = null;
 
         public override void OnLoad(ConfigNode node)

--- a/Source/Engines/ModuleEngineConfigs.cs
+++ b/Source/Engines/ModuleEngineConfigs.cs
@@ -62,8 +62,13 @@ namespace RealFuels
         #region Fields
         protected bool compatible = true;
 
-        [KSPField(isPersistant = true, guiActiveEditor = true, groupName = groupName, groupDisplayName = groupDisplayName)]
+        [KSPField(isPersistant = true)]
         public string configuration = string.Empty;
+
+        // For display purposes only.
+        [KSPField(guiName = "Configuration", isPersistant = true, guiActiveEditor = true,
+            groupName = groupName, groupDisplayName = groupDisplayName)]
+        public string configurationDisplay = string.Empty;
 
         // Tech Level stuff
         [KSPField(isPersistant = true)]
@@ -681,6 +686,8 @@ namespace RealFuels
             UpdateTFInterops(); // update TestFlight if it's installed
 
             StopFX();
+
+            configurationDisplay = GetConfigDisplayName(GetConfigByName(configuration));
         }
 
         virtual protected int ConfigIgnitions(int ignitions)

--- a/Source/Engines/ModuleEngineConfigs.cs
+++ b/Source/Engines/ModuleEngineConfigs.cs
@@ -34,7 +34,7 @@ namespace RealFuels
         public void SwitchEngine()
         {
             ConfigNode currentConfig = GetConfigByName(configuration);
-            string nextConfiguration = configs[(configs.IndexOf (currentConfig) + 1) % configs.Count].GetValue ("name");
+            string nextConfiguration = configs[(configs.IndexOf(currentConfig) + 1) % configs.Count].GetValue("name");
             SetConfiguration(nextConfiguration);
             // TODO: Does Engine Ignitor get switched here?
         }
@@ -1116,6 +1116,32 @@ namespace RealFuels
         private bool styleSetup = false;
         private bool editorLocked = false;
 
+        private int toolTipWidth => EditorLogic.fetch.editorScreen == EditorScreen.Parts ? 220 : 300;
+        private int _toolTipHash;
+        private int _toolTipHeight;
+        private int toolTipHeight
+        {
+            get
+            {
+                int hash = myToolTip.GetHashCode();
+                if (hash != _toolTipHash)
+                {
+                    _toolTipHash = hash;
+                    // This procedure is very much not rigorous/correct, but should work fine as an approximation.
+                    int numLines = myToolTip
+                        .Split('\n')
+                        .Select(line => new GUIContent(line))
+                        .Select(Styles.styleEditorTooltip.CalcSize)
+                        .Select(size => size.x / toolTipWidth * 0.95f) // Margins.
+                        .Select(Mathf.CeilToInt)
+                        .Sum();
+                    // Each line is 14px high, also add some extra just in case the computation is off.
+                    _toolTipHeight = (int)(numLines * 14 * 1.2);
+                }
+                return _toolTipHeight;
+            }
+        }
+
         public void OnGUI()
         {
             if (!compatible || !isMaster || !HighLogic.LoadedSceneIsEditor || EditorLogic.fetch == null)
@@ -1155,8 +1181,7 @@ namespace RealFuels
             if (!string.IsNullOrEmpty(myToolTip))
             {
                 int offset = inPartsEditor ? -222 : 440;
-                int width = inPartsEditor ? 220 : 300;
-                GUI.Label(new Rect(guiWindowRect.xMin + offset, mousePos.y - 5, width, 200), myToolTip, Styles.styleEditorTooltip);
+                GUI.Label(new Rect(guiWindowRect.xMin + offset, mousePos.y - 5, toolTipWidth, toolTipHeight), myToolTip, Styles.styleEditorTooltip);
             }
 
             guiWindowRect = GUILayout.Window(unchecked((int)part.persistentId), guiWindowRect, EngineManagerGUI, "Configure " + part.partInfo.title, Styles.styleEditorPanel);

--- a/Source/Engines/ModuleEngineConfigs.cs
+++ b/Source/Engines/ModuleEngineConfigs.cs
@@ -33,8 +33,8 @@ namespace RealFuels
         [KSPEvent(guiActive = true, guiName = "Switch Engine Mode")]
         public void SwitchEngine()
         {
-            ConfigNode currentConfig = configs.Find(c => c.GetValue("name").Equals(configuration));
-            string nextConfiguration = configs[(configs.IndexOf(currentConfig) + 1) % configs.Count].GetValue("name");
+            ConfigNode currentConfig = GetConfigByName(configuration);
+            string nextConfiguration = configs[(configs.IndexOf (currentConfig) + 1) % configs.Count].GetValue ("name");
             SetConfiguration(nextConfiguration);
             // TODO: Does Engine Ignitor get switched here?
         }
@@ -542,7 +542,7 @@ namespace RealFuels
 
             string val = string.Empty;
             IEnumerable<ConfigNode> others = configs.Where(x => !x.GetValue("name").Equals(configuration));
-            ConfigNode ours = configs.FirstOrDefault(x => x.GetValue("name").Equals(configuration));
+            ConfigNode ours = GetConfigByName(configuration);
             foreach (string fxName in effectsNames)
             {
                 foreach (ConfigNode cfg in others)
@@ -561,6 +561,7 @@ namespace RealFuels
 
         #region Configuration
         public PartModule pModule = null;
+        protected ConfigNode GetConfigByName(string name) => configs.Find(c => c.GetValue("name") == name);
 
         virtual public void SetConfiguration(string newConfiguration = null, bool resetTechLevels = false)
         {
@@ -576,7 +577,7 @@ namespace RealFuels
                 return;
             }
 
-            ConfigNode newConfig = configs.Find(c => c.GetValue("name").Equals(newConfiguration));
+            ConfigNode newConfig = GetConfigByName(newConfiguration);
             if (!(newConfig is ConfigNode))
             {
                 newConfig = configs.First();

--- a/Source/Engines/ModuleEngineConfigs.cs
+++ b/Source/Engines/ModuleEngineConfigs.cs
@@ -404,6 +404,8 @@ namespace RealFuels
             return retStr;
         }
 
+        virtual public string GetConfigDisplayName(ConfigNode node) => node.GetValue("name");
+
         public override string GetInfo()
         {
             if (!compatible)
@@ -429,7 +431,7 @@ namespace RealFuels
 
             if (colorName)
                 info.Append("<color=green>");
-            info.Append(config.GetValue("name"));
+            info.Append(GetConfigDisplayName(config));
             if (colorName)
                 info.Append("</color>");
             info.Append("\n");
@@ -1182,6 +1184,7 @@ namespace RealFuels
             foreach (ConfigNode node in GetGUIVisibleConfigs())
             {
                 string nName = node.GetValue("name");
+                string nNameDisp = GetConfigDisplayName(node);
                 GUILayout.BeginHorizontal();
 
                 // get cost
@@ -1199,7 +1202,7 @@ namespace RealFuels
 
                 if (nName.Equals(configuration))
                 {
-                    GUILayout.Label(new GUIContent($"Current config: {nName}{costString}", GetConfigInfo(node)));
+                    GUILayout.Label(new GUIContent($"Current config: {nNameDisp}{costString}", GetConfigInfo(node)));
                 }
                 else
                 {
@@ -1207,7 +1210,7 @@ namespace RealFuels
                     {
                         if (UnlockedConfig(node, part))
                         {
-                            if (GUILayout.Button(new GUIContent($"Switch to {nName}{costString}", GetConfigInfo(node))))
+                            if (GUILayout.Button(new GUIContent($"Switch to {nNameDisp}{costString}", GetConfigInfo(node))))
                             {
                                 SetConfiguration(nName, true);
                                 UpdateSymmetryCounterparts();
@@ -1221,7 +1224,7 @@ namespace RealFuels
                             if (upgradeCost > 0d)
                             {
                                 costString = $"({upgradeCost:N0}f)";
-                                if (GUILayout.Button(new GUIContent($"Purchase {nName}{costString}", GetConfigInfo(node))))
+                                if (GUILayout.Button(new GUIContent($"Purchase {nNameDisp}{costString}", GetConfigInfo(node))))
                                 {
                                     if (EntryCostManager.Instance.PurchaseConfig(nName))
                                     {
@@ -1235,7 +1238,7 @@ namespace RealFuels
                             {
                                 // autobuy
                                 EntryCostManager.Instance.PurchaseConfig(nName);
-                                if (GUILayout.Button(new GUIContent($"Switch to {nName}{costString}", GetConfigInfo(node))))
+                                if (GUILayout.Button(new GUIContent($"Switch to {nNameDisp}{costString}", GetConfigInfo(node))))
                                 {
                                     SetConfiguration(nName, true);
                                     UpdateSymmetryCounterparts();
@@ -1248,7 +1251,7 @@ namespace RealFuels
                     {
                         if (techNameToTitle.TryGetValue(node.GetValue("techRequired"), out string techStr))
                             techStr = "\nRequires: " + techStr;
-                        GUILayout.Label(new GUIContent("Lack tech for " + nName, GetConfigInfo(node) + techStr));
+                        GUILayout.Label(new GUIContent("Lack tech for " + nNameDisp, GetConfigInfo(node) + techStr));
                     }
                 }
                 GUILayout.EndHorizontal();

--- a/Source/Engines/ModuleEngineConfigs.cs
+++ b/Source/Engines/ModuleEngineConfigs.cs
@@ -1441,12 +1441,18 @@ namespace RealFuels
             if (configs.Count > 0)
             {
                 if (!RFSettings.Instance.engineConfigs.ContainsKey(partName))
-                    RFSettings.Instance.engineConfigs[partName] = new List<ConfigNode>(configs);
+                    OverwriteSavedConfigs();
             }
             else if (RFSettings.Instance.engineConfigs.ContainsKey(partName))
                 configs = new List<ConfigNode>(RFSettings.Instance.engineConfigs[partName]);
             else
                 Debug.LogError($"*RFMEC* ERROR: could not find configs definition for {partName}");
+        }
+        protected void OverwriteSavedConfigs()
+        {
+            string partName = Utilities.GetPartName(part) + moduleIndex + engineID;
+            if (configs.Count > 0)
+                RFSettings.Instance.engineConfigs[partName] = new List<ConfigNode>(configs);
         }
 
         protected static PartModule GetSpecifiedModule(Part p, string eID, int mIdx, string eType, bool weakType) => GetSpecifiedModules(p, eID, mIdx, eType, weakType).FirstOrDefault();

--- a/Source/Engines/ModuleEngineConfigs.cs
+++ b/Source/Engines/ModuleEngineConfigs.cs
@@ -1395,7 +1395,7 @@ namespace RealFuels
         #endregion
 
         #region Helpers
-        virtual public int UpdateSymmetryCounterparts()
+        public int DoForEachSymmetryCounterpart(Action<ModuleEngineConfigs> action)
         {
             int i = 0;
             int mIdx = moduleIndex;
@@ -1406,12 +1406,20 @@ namespace RealFuels
             {
                 if (GetSpecifiedModule(p, engineID, mIdx, GetType().Name, false) is ModuleEngineConfigs engine)
                 {
-                    engine.techLevel = techLevel;
-                    engine.SetConfiguration(configuration);
+                    action(engine);
                     ++i;
                 }
             }
             return i;
+        }
+
+        virtual public int UpdateSymmetryCounterparts()
+        {
+            return DoForEachSymmetryCounterpart((engine) =>
+            {
+                engine.techLevel = techLevel;
+                engine.SetConfiguration(configuration);
+            });
         }
 
         virtual protected void UpdateOtherModules(ConfigNode node)

--- a/Source/RealFuels.csproj
+++ b/Source/RealFuels.csproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -49,6 +49,9 @@
     <Reference Include="UnityEngine">
       <Private>False</Private>
     </Reference>
+    <Reference Include="UnityEngine.AnimationModule">
+      <Private>False</Private>
+    </Reference>
     <Reference Include="UnityEngine.CoreModule">
       <Private>False</Private>
     </Reference>
@@ -82,6 +85,7 @@
     <Compile Include="assembly\VersionReport.cs" />
     <Compile Include="EntryCosts\EngineConfigUpgrade.cs" />
     <Compile Include="Engines\ModuleEngineConfigs.cs" />
+    <Compile Include="Engines\ModuleAnimatedBimodalEngine.cs"/>
     <Compile Include="Engines\RFSettings.cs" />
     <Compile Include="Engines\ModuleEnginesRF.cs" />
     <Compile Include="Engines\SolverRF.cs" />

--- a/Source/RealFuels.csproj
+++ b/Source/RealFuels.csproj
@@ -85,7 +85,7 @@
     <Compile Include="assembly\VersionReport.cs" />
     <Compile Include="EntryCosts\EngineConfigUpgrade.cs" />
     <Compile Include="Engines\ModuleEngineConfigs.cs" />
-    <Compile Include="Engines\ModuleAnimatedBimodalEngine.cs"/>
+    <Compile Include="Engines\ModulePairedConfigEngine.cs"/>
     <Compile Include="Engines\RFSettings.cs" />
     <Compile Include="Engines\ModuleEnginesRF.cs" />
     <Compile Include="Engines\SolverRF.cs" />


### PR DESCRIPTION
This module is a hybrid of `ModuleHybridEngine` and `ROLDeployableEngine`. It ties configs into pairs of (primary, secondary)
and allows toggling only within a pair during flight. The transition can optionally be animated.

A "primary" config can declare a linked "secondary" config using the `secondaryConfig` key. All configs must be linked into such pairs, without any unlinked configs leftover and without any config linked to more than one other config.

The UI is modified so that only the primary configurations are selectable. To access the secondaries, a toggle button is added at the top. It also overrides the unlock logic: When unlocking or using a new primary config, the secondary will be auto-unlocked for free (since it doesn't make logical sense for the two modes to have different tech requirements, because they _are_ the same exact engine). 

An animation can be played during the transition, specified with the `animationName` key.

By default, the performance characteristics of the engine will be lerped smoothly during the duration of the animation, if one is defined. The lerp time can also be overridden (or set, if there is not an animation) using the `thrustLerpTime` key.

The names of the modes can be customized using 4 keys in MEC:

- `primaryDescription` and `secondaryDescription`: an adjective describing the two modes (ex. "retracted" and "extended").
- `toPrimaryText` and `toSecondaryText`: displayed on the mode toggle button. If these keys aren't set but the descriptions are, they will be generated as `$"To {description} mode"`.

This PR also adds a description to the top of the selector window to clarify how each MEC variant is different.