### PR TITLE
Updated ground lit info string

### DIFF
--- a/Source/Engines/ModuleEnginesRF.cs
+++ b/Source/Engines/ModuleEnginesRF.cs
@@ -502,7 +502,7 @@ namespace RealFuels
             else if (ignitions == -1)
                 sIgnitions = "Unlimited";
             else
-                sIgnitions = "<color=yellow>Ground-lit only</color>";
+                sIgnitions = "<color=yellow>Ground Support Clamps</color>";
 
             dispMass = part.mass;
         }
@@ -806,7 +806,7 @@ namespace RealFuels
         public string GetUllageIgnition()
         {
             string output = pressureFed ? "Pressure-fed" : string.Empty;
-            output += (output != string.Empty ? ", " : string.Empty) + "Ignitions: " + ((!RFSettings.Instance.limitedIgnitions || ignitions < 0) ? "Unlimited" : (ignitions > 0 ? ignitions.ToString() : "Ground only"));
+            output += (output != string.Empty ? ", " : string.Empty) + "Ignitions: " + ((!RFSettings.Instance.limitedIgnitions || ignitions < 0) ? "Unlimited" : (ignitions > 0 ? ignitions.ToString() : "Ground Support Clamps"));
             output += (output != string.Empty ? ", " : string.Empty) + (ullage ? "Subject" : "Not subject") + " to ullage";
             output += "\n";
 


### PR DESCRIPTION
It is common for players to see the "Ground lit only" string but not realize this means it requires clamps, and be confused.  This change clarifies things a bit by changing the string to be "Ground Support Clamps" for the Ignition text.