### PR TITLE
Gimbal management overhaul

### DIFF
--- a/Source/Engines/ModuleEngineConfigs.cs
+++ b/Source/Engines/ModuleEngineConfigs.cs
@@ -851,19 +851,19 @@ namespace RealFuels
             {
                 foreach (var node in cfg.GetNodes("GIMBAL"))
                 {
-                    if (!node.HasValue("gimbalTransformName"))
+                    if (!node.HasValue("gimbalTransform"))
                     {
-                        Debug.LogError($"*RFMEC* Config {cfg.GetValue("name")} of part {part.name} has a `GIMBAL` node without a `gimbalTransformName`!");
+                        Debug.LogError($"*RFMEC* Config {cfg.GetValue("name")} of part {part.name} has a `GIMBAL` node without a `gimbalTransform`!");
                         continue;
                     }
-                    gimbals[node.GetValue("gimbalTransformName")] = ExtractGimbalKeys(node);
+                    gimbals[node.GetValue("gimbalTransform")] = ExtractGimbalKeys(node);
                 }
             }
             else if (cfg.HasValue("gimbalRange"))
             {
                 var gimbal = ExtractGimbalKeys(cfg);
-                if (gimbalTransform != string.Empty)
-                    gimbals[gimbalTransform] = gimbal;
+                if (this.gimbalTransform != string.Empty)
+                    gimbals[this.gimbalTransform] = gimbal;
                 else
                     foreach (var g in part.Modules.OfType<ModuleGimbal>())
                         gimbals[g.gimbalTransformName] = gimbal;

--- a/Source/Engines/ModuleEngineConfigs.cs
+++ b/Source/Engines/ModuleEngineConfigs.cs
@@ -301,10 +301,7 @@ namespace RealFuels
 
                 if (HighLogic.LoadedSceneIsFlight
                     && B9PS_switchInFlight != null
-                    && !(bool)B9PS_switchInFlight.GetValue(module))
-                {
-                    continue;
-                }
+                    && !(bool)B9PS_switchInFlight.GetValue(module)) continue;
 
                 if (!subtypeSpecifications.TryGetValue(moduleID, out string subtypeName))
                 {
@@ -548,7 +545,7 @@ namespace RealFuels
             {
                 foreach (KeyValuePair<string, Gimbal> kv in ExtractGimbals(config))
                 {
-                    info.Append($"  Gimbal ({kv.Key}) {kv.Value.Info()}\n");
+                    info.Append($"  Gimbal ({kv.Key}): {kv.Value.Info()}\n");
                 }
             }
             else if (config.HasValue("gimbalRange"))
@@ -862,7 +859,6 @@ namespace RealFuels
                     gimbals[node.GetValue("gimbalTransformName")] = ExtractGimbalKeys(node);
                 }
             }
-
             else if (cfg.HasValue("gimbalRange"))
             {
                 var gimbal = ExtractGimbalKeys(cfg);

--- a/Source/Engines/ModuleEngineConfigs.cs
+++ b/Source/Engines/ModuleEngineConfigs.cs
@@ -125,7 +125,7 @@ namespace RealFuels
         [KSPField]
         public bool useGimbalAnyway = false;
 
-        private Dictionary<string, Gimbal> defaultGimbals = new Dictionary<string, Gimbal>();
+        private Dictionary<string, Gimbal> defaultGimbals = null;
 
         [KSPField]
         public bool autoUnlock = true;
@@ -393,9 +393,6 @@ namespace RealFuels
             foreach (ConfigNode n in node.GetNodes("TECHLEVEL"))
                 techNodes.AddNode(n);
 
-            foreach (var g in part.Modules.OfType<ModuleGimbal>())
-                defaultGimbals[g.gimbalTransformName] = new Gimbal(g.gimbalRange, g.gimbalRangeXP, g.gimbalRangeXN, g.gimbalRangeYP, g.gimbalRangeYN);
-
             ConfigSaveLoad();
 
             SetConfiguration();
@@ -415,6 +412,10 @@ namespace RealFuels
             ConfigSaveLoad();
 
             LoadB9PSModules();
+
+            defaultGimbals = new Dictionary<string, Gimbal>();
+            foreach (var g in part.Modules.OfType<ModuleGimbal>())
+                defaultGimbals[g.gimbalTransformName] = new Gimbal(g.gimbalRange, g.gimbalRangeXP, g.gimbalRangeXN, g.gimbalRangeYP, g.gimbalRangeYN);
 
             SetConfiguration();
 
@@ -877,6 +878,9 @@ namespace RealFuels
 
         private void SetGimbalRange(ConfigNode cfg)
         {
+            // Do not override gimbals before default gimbals have been extracted.
+            if (defaultGimbals == null) return;
+
             Dictionary<string, Gimbal> gimbalOverrides = ExtractGimbals(cfg);
             foreach (ModuleGimbal mg in part.Modules.OfType<ModuleGimbal>())
             {

--- a/Source/Engines/ModuleEngineConfigs.cs
+++ b/Source/Engines/ModuleEngineConfigs.cs
@@ -55,15 +55,15 @@ namespace RealFuels
         }
     }
 
-    internal struct Gimbal
+    public struct Gimbal
     {
-        internal float gimbalRange;
-        internal float gimbalRangeXP;
-        internal float gimbalRangeXN;
-        internal float gimbalRangeYP;
-        internal float gimbalRangeYN;
+        public float gimbalRange;
+        public float gimbalRangeXP;
+        public float gimbalRangeXN;
+        public float gimbalRangeYP;
+        public float gimbalRangeYN;
 
-        internal Gimbal(float gimbalRange, float gimbalRangeXP, float gimbalRangeXN, float gimbalRangeYP, float gimbalRangeYN)
+        public Gimbal(float gimbalRange, float gimbalRangeXP, float gimbalRangeXN, float gimbalRangeYP, float gimbalRangeYN)
         {
             this.gimbalRange = gimbalRange;
             this.gimbalRangeXP = gimbalRangeXP;
@@ -72,7 +72,7 @@ namespace RealFuels
             this.gimbalRangeYN = gimbalRangeYN;
         }
 
-        internal string Info()
+        public string Info()
         {
             if (new[] { gimbalRange, gimbalRangeXP, gimbalRangeXN, gimbalRangeYP, gimbalRangeYN }.Distinct().Count() == 1)
                 return $"{gimbalRange:N1}d";
@@ -1628,7 +1628,7 @@ namespace RealFuels
             return _searchList;
         }
 
-        internal void MarkWindowDirty()
+        public void MarkWindowDirty()
         {
             if (UIPartActionController.Instance?.GetItem(part) is UIPartActionWindow action_window)
                 action_window.displayDirty = true;

--- a/Source/Engines/ModuleEngineConfigs.cs
+++ b/Source/Engines/ModuleEngineConfigs.cs
@@ -80,9 +80,9 @@ namespace RealFuels
                 return $"{gimbalRangeXP:N1}d";
             var ret = string.Empty;
             if (gimbalRangeXP == gimbalRangeXN)
-                ret += $"{gimbalRangeXP:N1}d pitch; ";
+                ret += $"{gimbalRangeXP:N1}d pitch, ";
             else
-                ret += $"+{gimbalRangeXP:N1}d/-{gimbalRangeXN:N1}d pitch; ";
+                ret += $"+{gimbalRangeXP:N1}d/-{gimbalRangeXN:N1}d pitch, ";
             if (gimbalRangeYP == gimbalRangeYN)
                 ret += $"{gimbalRangeYP:N1}d yaw";
             else
@@ -550,8 +550,11 @@ namespace RealFuels
             }
             else if (config.HasValue("gimbalRange"))
             {
-                float gimbalR = float.Parse(config.GetValue("gimbalRange"));
-                info.Append($"  Gimbal {gimbalR:N1}d\n");
+                // The extracted gimbals contain `gimbalRange` et al. applied to either a specific
+                // transform or all the gimbal transforms on the part. Either way, the values
+                // are all the same, so just take the first one.
+                var gimbal = ExtractGimbals(config).Values.First();
+                info.Append($"  Gimbal {gimbal.Info()}\n");
             }
 
             if (config.HasValue("ullage") || config.HasValue("ignitions") || config.HasValue("pressureFed"))

--- a/Source/Engines/ModuleEngineConfigs.cs
+++ b/Source/Engines/ModuleEngineConfigs.cs
@@ -1628,7 +1628,7 @@ namespace RealFuels
             return _searchList;
         }
 
-        public void MarkWindowDirty()
+        internal void MarkWindowDirty()
         {
             if (UIPartActionController.Instance?.GetItem(part) is UIPartActionWindow action_window)
                 action_window.displayDirty = true;


### PR DESCRIPTION
- Allow management of multiple gimbal transforms
- Store the default gimbal values for all modules, so that they can be restored when a config without gimbal overrides is selected

This introduces a new notation for specifying overrides for multiple gimbal transforms, which takes precedence over the old `gimbalRange`, `gimbalRangeXP`, &c. in `CONFIG` notation. The new form is a `GIMBAL` node, containing the `gimbalTransform` key and the normal gimbal range keys. There can be arbitrarily many `GIMBAL` keys in a single `CONFIG`.

If a `CONFIG` does not specify a `GIMBAL` (or a plain `gimbalRange`) for a certain transform, then the default value (as specified in the original `ModuleGimbal`) will be applied. This lifts the requirement (bug, really) that if one config specifies a gimbal override, then all configs must do.

The info box has also been updated to display more detailed gimbal information:

![image](https://user-images.githubusercontent.com/35266431/133358749-a681a5f9-5d0d-44b5-8ff3-38398b94b45a.png)
