### PR TITLE
Corrections to probabilities found when looking for variance bug

### DIFF
--- a/Source/Engines/SolverRF.cs
+++ b/Source/Engines/SolverRF.cs
@@ -348,7 +348,7 @@ namespace RealFuels
             varianceMR = GetNormal(useSeed, 3d) * (0.5d + Math.Abs(varianceFlow) * 0.5d);
             // MR probably has an effect on Isp but it's hard to say what. When running fuel-rich, increasing
             // oxidizer might raise Isp? And vice versa for ox-rich. So for now ignore MR.
-            varianceIsp = (varianceFlow * 0.8d + GetNormal(useSeed, 3d) * 0.2d);
+            varianceIsp = (varianceFlow * Math.Sqrt(0.8d) + GetNormal(useSeed, 3d) * Math.Sqrt(0.2d));
         }
 
         protected double GetNormal(bool useSeed, double stdDevClamp)

--- a/Source/Engines/SolverRF.cs
+++ b/Source/Engines/SolverRF.cs
@@ -353,20 +353,21 @@ namespace RealFuels
 
         protected double GetNormal(bool useSeed, double stdDevClamp)
         {
-            double u, v, S;
-
+            double u, v, S, retVal;
             do
             {
-                u = GetRandom(useSeed);
-                v = GetRandom(useSeed);
-                S = u * u + v * v;
-            }
-            while (S >= 1d);
+                do
+                {
+                    u = GetRandom(useSeed);
+                    v = GetRandom(useSeed);
+                    S = u * u + v * v;
+                }
+                while (S >= 1d);
 
-            double fac = Math.Sqrt(-2.0 * Math.Log(S) / S);
-            double retVal = u * fac;
-            if (stdDevClamp > 0)
-                retVal = Math.Min(stdDevClamp, Math.Abs(retVal)) * Math.Sign(retVal);
+                double fac = Math.Sqrt(-2.0 * Math.Log(S) / S);
+                retVal = u * fac;
+            }
+            while (Math.Abs(retVal)>stdDevClamp);
             return retVal;
         }
     }

--- a/Source/Engines/SolverRF.cs
+++ b/Source/Engines/SolverRF.cs
@@ -367,7 +367,7 @@ namespace RealFuels
                 double fac = Math.Sqrt(-2.0 * Math.Log(S) / S);
                 retVal = u * fac;
             }
-            while (Math.Abs(retVal)>stdDevClamp);
+            while (stdDevClamp > 0 && Math.Abs(retVal)>stdDevClamp);
             return retVal;
         }
     }


### PR DESCRIPTION
Changed normal distribution to reroll if it falls outside the desired range, instead of clamping it. This avoids a problem where the edge value of the interval was more likely to occur than some values closer to the mean.

Changed the weights in `varianceIsp` to have the correct variance of `1`.