### PR TITLE
Add config display filters support

### DIFF
--- a/Source/Engines/ConfigFilters.cs
+++ b/Source/Engines/ConfigFilters.cs
@@ -12,16 +12,21 @@ namespace RealFuels
         {
             if (run)
             {
-                Debug.Log("[RealFuelsFilters] Updated Info boxes");
+                Debug.Log("[RealFuelsFilters] Updated info boxes");
                 foreach (AvailablePart ap in PartLoader.LoadedPartsList)
                 {
-                    if (ap.partPrefab.FindModuleImplementing<ModuleEngineConfigs>() is ModuleEngineConfigs mec)
+                    // workaround for FindModulesImplementing nullrefs when called on the strange kerbalEVA_RD_Exp prefab
+                    // due to the (private) cachedModuleLists being null on it
+                    if (ap.partPrefab.Modules.Count == 0)
+                        continue;
+                    if (ap.partPrefab.FindModulesImplementing<ModuleEngineConfigs>() is List<ModuleEngineConfigs> mecs)
                     {
+                        int i = 0;
                         foreach (AvailablePart.ModuleInfo x in ap.moduleInfos)
                         {
                             if (x.moduleName.Equals("Engine Configs"))
                             {
-                                x.info = mec.GetInfo();
+                                x.info = mecs[i++].GetInfo();
                             }
                         }
                     }
@@ -35,71 +40,11 @@ namespace RealFuels
 
     public class ConfigFilters
     {
-        public class Filter
-        {
-            public string filterID;
-            public Func<ConfigNode, bool> criteria;
-
-            public Filter(string filterID, Func<ConfigNode, bool> criteria)
-            {
-                this.filterID = filterID;
-                this.criteria = criteria;
-            }
-        }
-
-        public class FilterList
-        {
-            private List<Filter> filterList;
-
-            public FilterList()
-            {
-                this.filterList = new List<Filter>();
-            }
-
-            public void AddFilter(Filter filter)
-            {
-                if (this.filterList.Contains(filter))
-                {
-                    return;
-                }
-                this.filterList.Add(filter);
-            }
-
-            public void RemoveFilter(string id)
-            {
-                RemoveFilter(GetFilterFromID(id));
-            }
-
-            public void RemoveFilter(Filter filter)
-            {
-                if (!this.filterList.Contains(filter))
-                {
-                    return;
-                }
-                this.filterList.Remove(filter);
-            }
-
-            public Filter GetFilterFromID(string id)
-            {
-                foreach (var filter in this.filterList)
-                {
-                    if (filter.filterID == id)
-                    {
-                        return filter;
-                    }
-                }
-                return null;
-            }
-
-            public List<Filter>.Enumerator GetEnumerator() => this.filterList.GetEnumerator();
-
-        }
-
-        public FilterList configDisplayFilters;
+        public Dictionary<string, Func<ConfigNode, bool>> configDisplayFilters;
 
         public ConfigFilters()
         {
-            this.configDisplayFilters = new FilterList();
+            this.configDisplayFilters = new Dictionary<string, Func<ConfigNode, bool>>();
         }
 
 
@@ -108,7 +53,7 @@ namespace RealFuels
             return FilterConfigs(configs, configDisplayFilters);
         }
 
-        public List<ConfigNode> FilterConfigs(List<ConfigNode> configs, FilterList filters)
+        private List<ConfigNode> FilterConfigs(List<ConfigNode> configs, Dictionary<string, Func<ConfigNode, bool>> filters)
         {
             List<ConfigNode> filteredConfigs = new List<ConfigNode>(configs);
             foreach (var filter in filters)
@@ -116,7 +61,7 @@ namespace RealFuels
                 int count = filteredConfigs.Count;
                 while(count-- > 0)
                 {
-                    if (!filter.criteria(filteredConfigs[count]))
+                    if (!filter.Value(filteredConfigs[count]))
                         filteredConfigs.RemoveAt(count);
                 }
             }

--- a/Source/Engines/ConfigFilters.cs
+++ b/Source/Engines/ConfigFilters.cs
@@ -4,6 +4,35 @@ using UnityEngine;
 
 namespace RealFuels
 {
+    [KSPAddon(KSPAddon.Startup.EditorAny, false)]
+    public class ModuleShowInfoUpdater : MonoBehaviour
+    {
+        protected bool run = true;
+        private void Update()
+        {
+            if (run)
+            {
+                Debug.Log("[RealFuelsFilters] Updated Info boxes");
+                foreach (AvailablePart ap in PartLoader.LoadedPartsList)
+                {
+                    if (ap.partPrefab.FindModuleImplementing<ModuleEngineConfigs>() is ModuleEngineConfigs mec)
+                    {
+                        foreach (AvailablePart.ModuleInfo x in ap.moduleInfos)
+                        {
+                            if (x.moduleName.Equals("Engine Configs"))
+                            {
+                                x.info = mec.GetInfo();
+                            }
+                        }
+                    }
+                }
+
+                run = false;
+                GameObject.Destroy(this);
+            }
+        }
+    }
+
     public class ConfigFilters
     {
         public class Filter

--- a/Source/Engines/ConfigFilters.cs
+++ b/Source/Engines/ConfigFilters.cs
@@ -4,7 +4,7 @@ using UnityEngine;
 
 namespace RealFuels
 {
-    [KSPAddon(KSPAddon.Startup.EditorAny, false)]
+    [KSPAddon(KSPAddon.Startup.AllGameScenes, false)]
     public class ModuleShowInfoUpdater : MonoBehaviour
     {
         protected bool run = true;

--- a/Source/Engines/ConfigFilters.cs
+++ b/Source/Engines/ConfigFilters.cs
@@ -100,7 +100,7 @@ namespace RealFuels
             get
             {
                 if (_instance == null)
-                    return new ConfigFilters();
+                    _instance = new ConfigFilters();
                 return _instance;
             }
         }

--- a/Source/Engines/ConfigFilters.cs
+++ b/Source/Engines/ConfigFilters.cs
@@ -4,7 +4,7 @@ using UnityEngine;
 
 namespace RealFuels
 {
-    public class ConfigFilters : MonoBehaviour
+    public class ConfigFilters
     {
         public class FilterList
         {
@@ -38,6 +38,11 @@ namespace RealFuels
         }
         public FilterList configDisplayFilters;
 
+        public ConfigFilters()
+        {
+            this.configDisplayFilters = new FilterList();
+        }
+
 
         public List<ConfigNode> FilterDisplayConfigs(List<ConfigNode> configs)
         {
@@ -64,13 +69,8 @@ namespace RealFuels
         {
             get
             {
-                if (_instance != null && _instance)
-                    return _instance;
-
-                GameObject gameObject = new GameObject(typeof(ConfigFilters).FullName);
-                _instance = gameObject.AddComponent<ConfigFilters>();
-                UnityEngine.Object.DontDestroyOnLoad(_instance);
-                UnityEngine.Object.DontDestroyOnLoad(gameObject);
+                if (_instance == null)
+                    return new ConfigFilters();
                 return _instance;
             }
         }

--- a/Source/Engines/ConfigFilters.cs
+++ b/Source/Engines/ConfigFilters.cs
@@ -1,0 +1,47 @@
+using System;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace RealFuels
+{
+    public class ConfigFilters : MonoBehaviour
+    {
+        public List<Func<ConfigNode, bool>> configDisplayFilters;
+
+        public List<ConfigNode> FilterDisplayConfigs(List<ConfigNode> configs)
+        {
+            return FilterConfigs(configs, configDisplayFilters);
+        }
+
+        public List<ConfigNode> FilterConfigs(List<ConfigNode> configs, List<Func<ConfigNode,bool>> filters)
+        {
+            List<ConfigNode> filteredConfigs = new List<ConfigNode>(configs);
+            foreach (var filter in filters)
+            {
+                int count = filteredConfigs.Count;
+                while(count-- > 0)
+                {
+                    if (!filter(filteredConfigs[count]))
+                        filteredConfigs.RemoveAt(count);
+                }
+            }
+            return filteredConfigs;
+        }
+
+        private static ConfigFilters _instance;
+        public static ConfigFilters Instance
+        {
+            get
+            {
+                if (_instance != null && _instance)
+                    return _instance;
+
+                GameObject gameObject = new GameObject(typeof(ConfigFilters).FullName);
+                _instance = gameObject.AddComponent<ConfigFilters>();
+                UnityEngine.Object.DontDestroyOnLoad(_instance);
+                UnityEngine.Object.DontDestroyOnLoad(gameObject);
+                return _instance;
+            }
+        }
+    }
+}

--- a/Source/Engines/ConfigFilters.cs
+++ b/Source/Engines/ConfigFilters.cs
@@ -6,16 +6,28 @@ namespace RealFuels
 {
     public class ConfigFilters
     {
+        public class Filter
+        {
+            public string filterID;
+            public Func<ConfigNode, bool> criteria;
+
+            public Filter(string filterID, Func<ConfigNode, bool> criteria)
+            {
+                this.filterID = filterID;
+                this.criteria = criteria;
+            }
+        }
+
         public class FilterList
         {
-            private List<Func<ConfigNode, bool>> filterList;
+            private List<Filter> filterList;
 
             public FilterList()
             {
-                this.filterList = new List<Func<ConfigNode, bool>>();
+                this.filterList = new List<Filter>();
             }
 
-            public void AddFilter(Func<ConfigNode, bool> filter)
+            public void AddFilter(Filter filter)
             {
                 if (this.filterList.Contains(filter))
                 {
@@ -24,7 +36,12 @@ namespace RealFuels
                 this.filterList.Add(filter);
             }
 
-            public void RemoveFilter(Func<ConfigNode, bool> filter)
+            public void RemoveFilter(string id)
+            {
+                RemoveFilter(GetFilterFromID(id));
+            }
+
+            public void RemoveFilter(Filter filter)
             {
                 if (!this.filterList.Contains(filter))
                 {
@@ -33,9 +50,22 @@ namespace RealFuels
                 this.filterList.Remove(filter);
             }
 
-            public List<Func<ConfigNode, bool>>.Enumerator GetEnumerator() => this.filterList.GetEnumerator();
+            public Filter GetFilterFromID(string id)
+            {
+                foreach (var filter in this.filterList)
+                {
+                    if (filter.filterID == id)
+                    {
+                        return filter;
+                    }
+                }
+                return null;
+            }
+
+            public List<Filter>.Enumerator GetEnumerator() => this.filterList.GetEnumerator();
 
         }
+
         public FilterList configDisplayFilters;
 
         public ConfigFilters()
@@ -57,7 +87,7 @@ namespace RealFuels
                 int count = filteredConfigs.Count;
                 while(count-- > 0)
                 {
-                    if (!filter(filteredConfigs[count]))
+                    if (!filter.criteria(filteredConfigs[count]))
                         filteredConfigs.RemoveAt(count);
                 }
             }

--- a/Source/Engines/ConfigFilters.cs
+++ b/Source/Engines/ConfigFilters.cs
@@ -6,14 +6,45 @@ namespace RealFuels
 {
     public class ConfigFilters : MonoBehaviour
     {
-        public List<Func<ConfigNode, bool>> configDisplayFilters;
+        public class FilterList
+        {
+            private List<Func<ConfigNode, bool>> filterList;
+
+            public FilterList()
+            {
+                this.filterList = new List<Func<ConfigNode, bool>>();
+            }
+
+            public void AddFilter(Func<ConfigNode, bool> filter)
+            {
+                if (this.filterList.Contains(filter))
+                {
+                    return;
+                }
+                this.filterList.Add(filter);
+            }
+
+            public void RemoveFilter(Func<ConfigNode, bool> filter)
+            {
+                if (!this.filterList.Contains(filter))
+                {
+                    return;
+                }
+                this.filterList.Remove(filter);
+            }
+
+            public List<Func<ConfigNode, bool>>.Enumerator GetEnumerator() => this.filterList.GetEnumerator();
+
+        }
+        public FilterList configDisplayFilters;
+
 
         public List<ConfigNode> FilterDisplayConfigs(List<ConfigNode> configs)
         {
             return FilterConfigs(configs, configDisplayFilters);
         }
 
-        public List<ConfigNode> FilterConfigs(List<ConfigNode> configs, List<Func<ConfigNode,bool>> filters)
+        public List<ConfigNode> FilterConfigs(List<ConfigNode> configs, FilterList filters)
         {
             List<ConfigNode> filteredConfigs = new List<ConfigNode>(configs);
             foreach (var filter in filters)

--- a/Source/Engines/ModuleBimodalEngineConfigs.cs
+++ b/Source/Engines/ModuleBimodalEngineConfigs.cs
@@ -38,7 +38,7 @@ namespace RealFuels
         {
             foreach (var node in configs)
             {
-                if (GetPatchesOfConfig(node).Length != 1)
+                if (GetPatchesOfConfig(node).Count != 1)
                     Debug.LogError($"**ModuleAnimatedBimodalEngine** Configuration {node.GetValue("name")} does not specify a `SUBCONFIG` for its `{secondaryDescription}` mode!");
             }
         }

--- a/Source/Engines/ModuleBimodalEngineConfigs.cs
+++ b/Source/Engines/ModuleBimodalEngineConfigs.cs
@@ -120,11 +120,11 @@ namespace RealFuels
             return info;
         }
 
-        protected override void DrawConfigSelectors()
+        protected override void DrawConfigSelectors(IEnumerable<ConfigNode> availableConfigNodes)
         {
             if (GUILayout.Button(new GUIContent(ToggleText, toggleButtonHoverInfo)))
                 ToggleMode();
-            foreach (var node in configs)
+            foreach (var node in availableConfigNodes)
             {
                 bool hasSecondary = ConfigHasSecondary(node);
                 var nodeApplied = IsSecondaryMode && hasSecondary ? SecondaryConfig(node) : node;

--- a/Source/Engines/ModuleEngineConfigs.cs
+++ b/Source/Engines/ModuleEngineConfigs.cs
@@ -330,8 +330,10 @@ namespace RealFuels
         private List<ConfigNode> FilterDisplayConfigs()
         {
             if (displayConfigsNeedUpdating)
+            {
                  _filteredDisplayConfigs = ConfigFilters.Instance.FilterDisplayConfigs(configs);
                  displayConfigsNeedUpdating = false;
+            }
             return _filteredDisplayConfigs;
         }
 

--- a/Source/Engines/ModuleEngineConfigs.cs
+++ b/Source/Engines/ModuleEngineConfigs.cs
@@ -129,6 +129,7 @@ namespace RealFuels
         public bool literalZeroIgnitions = false; /* Normally, ignitions = 0 means unlimited.  Setting this changes it to really mean zero */
 
         public List<ConfigNode> configs;
+        public List<ConfigNode> filteredDisplayConfigs;
         public ConfigNode config;
 
         public static Dictionary<string, string> techNameToTitle = new Dictionary<string, string>();
@@ -1370,9 +1371,9 @@ namespace RealFuels
             }
         }
 
-        virtual protected void DrawConfigSelectors()
+        virtual protected void DrawConfigSelectors(IEnumerable<ConfigNode> availableConfigNodes)
         {
-            foreach (ConfigNode node in configs)
+            foreach (ConfigNode node in availableConfigNodes)
                 DrawSelectButton(node, node.GetValue("name") == configuration, GUIApplyConfig);
         }
 
@@ -1487,7 +1488,7 @@ namespace RealFuels
             GUILayout.Label(EditorDescription);
             GUILayout.EndHorizontal();
 
-            DrawConfigSelectors();
+            DrawConfigSelectors(filteredDisplayConfigs);
             DrawTechLevelSelector();
             DrawPartInfo();
 
@@ -1573,6 +1574,8 @@ namespace RealFuels
                     if (configs.Count > 0)
                         RFSettings.Instance.engineConfigs[partName] = new List<ConfigNode>(configs);
                 }
+                // Is this a good location to set filtered configs?
+                filteredDisplayConfigs = ConfigFilters.Instance.FilterDisplayConfigs(configs);
             }
             else if (RFSettings.Instance.engineConfigs.ContainsKey(partName))
                 configs = new List<ConfigNode>(RFSettings.Instance.engineConfigs[partName]);

--- a/Source/Engines/ModuleEngineConfigs.cs
+++ b/Source/Engines/ModuleEngineConfigs.cs
@@ -129,7 +129,7 @@ namespace RealFuels
         public bool literalZeroIgnitions = false; /* Normally, ignitions = 0 means unlimited.  Setting this changes it to really mean zero */
 
         public List<ConfigNode> configs;
-        internal List<ConfigNode> _filteredDisplayConfigs;
+        internal List<ConfigNode> filteredDisplayConfigs;
         public ConfigNode config;
 
         public static Dictionary<string, string> techNameToTitle = new Dictionary<string, string>();
@@ -327,11 +327,11 @@ namespace RealFuels
 
         private List<ConfigNode> FilteredDisplayConfigs(bool update)
         {
-            if (update || _filteredDisplayConfigs == null)
+            if (update || filteredDisplayConfigs == null)
             {
-                _filteredDisplayConfigs = ConfigFilters.Instance.FilterDisplayConfigs(configs);
+                filteredDisplayConfigs = ConfigFilters.Instance.FilterDisplayConfigs(configs);
             }
-            return _filteredDisplayConfigs;
+            return filteredDisplayConfigs;
         }
 
         #region PartModule Overrides

--- a/Source/Engines/ModuleEnginesRF.cs
+++ b/Source/Engines/ModuleEnginesRF.cs
@@ -11,6 +11,10 @@ namespace RealFuels
         public const string groupName = "ModuleEnginesRF";
         public const string groupDisplayName = "Engine";
         #region Fields
+
+        [KSPField]
+        public string specLevel = "real";
+
         [KSPField]
         public double chamberNominalTemp = 0d;
         [KSPField]

--- a/Source/Engines/ModuleEnginesRF.cs
+++ b/Source/Engines/ModuleEnginesRF.cs
@@ -11,10 +11,6 @@ namespace RealFuels
         public const string groupName = "ModuleEnginesRF";
         public const string groupDisplayName = "Engine";
         #region Fields
-
-        [KSPField]
-        public string specLevel = "real";
-
         [KSPField]
         public double chamberNominalTemp = 0d;
         [KSPField]

--- a/Source/Engines/ModulePatchableEngineConfigs.cs
+++ b/Source/Engines/ModulePatchableEngineConfigs.cs
@@ -16,9 +16,14 @@ namespace RealFuels
         [KSPField(isPersistant = true)]
         public bool dynamicPatchApplied = false;
 
-        protected bool ConfigHasPatch(ConfigNode config) => config.HasNode(PatchNodeName);
+        protected bool ConfigHasPatch(ConfigNode config) => GetPatchesOfConfig(config).Count > 0;
 
-        protected ConfigNode[] GetPatchesOfConfig(ConfigNode config) => config.GetNodes(PatchNodeName);
+        protected List<ConfigNode> GetPatchesOfConfig(ConfigNode config)
+        {
+            ConfigNode[] list = config.GetNodes(PatchNodeName);
+            List<ConfigNode> sortedList = ConfigFilters.Instance.FilterDisplayConfigs(list.ToList());
+            return sortedList;
+        }
 
         protected ConfigNode GetPatch(string configName, string patchName)
         {

--- a/Source/Engines/ModulePatchableEngineConfigs.cs
+++ b/Source/Engines/ModulePatchableEngineConfigs.cs
@@ -1,6 +1,8 @@
 using System.Linq;
 using UnityEngine;
 
+using System.Collections.Generic;
+
 namespace RealFuels
 {
     public class ModulePatchableEngineConfigs : ModuleEngineConfigs
@@ -100,9 +102,9 @@ namespace RealFuels
             return $"{name} [Subconfig {node.GetValue(PatchNameKey)}]";
         }
 
-        protected override void DrawConfigSelectors()
+        protected override void DrawConfigSelectors(IEnumerable<ConfigNode> availableConfigNodes)
         {
-            foreach (var node in configs)
+            foreach (var node in availableConfigNodes)
             {
                 DrawSelectButton(
                     node,

--- a/Source/RealFuels.csproj
+++ b/Source/RealFuels.csproj
@@ -84,6 +84,7 @@
     <Compile Include="assembly\Checkers.cs" />
     <Compile Include="assembly\VersionReport.cs" />
     <Compile Include="EntryCosts\EngineConfigUpgrade.cs" />
+    <Compile Include="Engines\ConfigFilters.cs" />
     <Compile Include="Engines\ModuleBimodalEngineConfigs.cs" />
     <Compile Include="Engines\ModuleEngineConfigs.cs" />
     <Compile Include="Engines\ModuleHybridEngine.cs" />


### PR DESCRIPTION
Adds a system to allow filters to be added to change what configs are displayed. All configs continue to exist even if they are not shown.

Hides configs in the selector GUI, but also in the part info box

Filters are attached as `Func<ConfigNode, bool>` added to `ConfigFilters.Instance.configDisplayFilters`.