### PR TITLE
Bugfix: SolverEngines removed engineTempString

### DIFF
--- a/Source/Engines/ModuleEnginesRF.cs
+++ b/Source/Engines/ModuleEnginesRF.cs
@@ -482,7 +482,6 @@ namespace RealFuels
             Fields[nameof(thrustCurveDisplay)].guiActive = useThrustCurve;
 
             var group = Fields[nameof(propellantStatus)].group;
-            Fields[nameof(engineTempString)].group = group;
             Fields[nameof(actualThrottle)].group = group;
             Fields[nameof(realIsp)].group = group;
             Fields[nameof(finalThrust)].group = group;

--- a/Source/Engines/ModuleEnginesRF.cs
+++ b/Source/Engines/ModuleEnginesRF.cs
@@ -482,6 +482,7 @@ namespace RealFuels
             Fields[nameof(thrustCurveDisplay)].guiActive = useThrustCurve;
 
             var group = Fields[nameof(propellantStatus)].group;
+            Fields[nameof(engineTemp)].group = group;
             Fields[nameof(actualThrottle)].group = group;
             Fields[nameof(realIsp)].group = group;
             Fields[nameof(finalThrust)].group = group;

--- a/Source/Ullage/UllageModule.cs
+++ b/Source/Ullage/UllageModule.cs
@@ -64,15 +64,11 @@ namespace RealFuels.Ullage
             }
 
 #if DEBUG
-            var str = new System.Text.StringBuilder("Ullage states: ");
+            var str = StringBuilderCache.Acquire();
+            str.AppendLine("Ullage states:");
             foreach (var set in ullageSets)
-            {
-                str.Append(set.Engine());
-                str.Append(" is ");
-                str.Append(set.GetUllageStability().ToString("N4"));
-                str.Append("\n");
-            }
-            print(str);
+                str.AppendLine($"{set.Engine()} is {set.GetUllageStability():N4}");
+            Debug.Log(str.ToStringAndRelease());
 #endif
         }
 

--- a/Source/assembly/AssemblyInfoRF.in
+++ b/Source/assembly/AssemblyInfoRF.in
@@ -28,4 +28,4 @@ using System.Runtime.CompilerServices;
 //[assembly: AssemblyKeyFile("")]
 
 [assembly: KSPAssembly("RealFuels", @MAJOR_VERSION@, @MINOR_VERSION@, @PATCH_VERSION@)]
-[assembly: KSPAssemblyDependency("SolverEngines", 3, 3)]
+[assembly: KSPAssemblyDependency("SolverEngines", 3, 13)]


### PR DESCRIPTION
Feature was moved into guiUnits of another KSPField.  Don't reference it anymore.