### PR TITLE
Integrate with the config validation feature from RP0KCT

### DIFF
--- a/Source/Utilities/Utilities.cs
+++ b/Source/Utilities/Utilities.cs
@@ -55,6 +55,20 @@ namespace RealFuels
             }
         }
 
+        private static bool? _RP1Found = null;
+        public static bool RP1Found
+        {
+            get
+            {
+                if (!_RP1Found.HasValue)
+                {
+                    var assembly = AssemblyLoader.loadedAssemblies.FirstOrDefault(a => a.assembly.GetName().Name == "RP0")?.assembly;
+                    _RP1Found = (assembly is Assembly);
+                }
+                return _RP1Found.Value;
+            }
+        }
+
         public static FloatCurve Mod(FloatCurve fc, float sMult, float vMult)
         {
             FloatCurve newCurve = new FloatCurve();


### PR DESCRIPTION
This also means that we now allow selecting configs despite tech status or whether the entry cost has been paid.
![image](https://user-images.githubusercontent.com/1120038/154993402-a5dcff5a-610b-4d99-b6be-368998eada34.png)
