### PR TITLE
Fix version file syntax error

### DIFF
--- a/RealFuels/RealFuels.version
+++ b/RealFuels/RealFuels.version
@@ -19,7 +19,7 @@
 		"MAJOR": 1,
 		"MINOR": 12,
 		"PATCH": 0
-	}
+	},
 
 	"KSP_VERSION_MAX":
 	{


### PR DESCRIPTION
Hi @siimav,

We just got this notification in the CKAN Discord:

![image](https://user-images.githubusercontent.com/1559108/158903566-73754820-3b6c-46c8-9a7d-394b820676dd.png)

That means there's a syntax error in the version file of the latest release (note that this will prevent that release from being added to CKAN). This pull request fixes it.

To catch problems like this before release next time, consider using @DasSkelett's version file validator action:

- https://github.com/DasSkelett/AVC-VersionFileValidator