### PR TITLE
Fix cfg syntax errors

### DIFF
--- a/RealFuels/NearFuture_Propulsion_modularFuelTanks.cfg
+++ b/RealFuels/NearFuture_Propulsion_modularFuelTanks.cfg
@@ -40,7 +40,7 @@
 	@title = ARG-600K Electric Propulsion Tank
 	@description = Originally designed to hold propane fuel for the KSC's kitchens, this tank was repurposed (stolen) by an Argyle engineer (janitor) and converted to hold his favourite noble gases.
 	@cost *= 8
-	!RESOURCE[ArgonGas]
+	!RESOURCE[ArgonGas] {}
 	MODULE
 	{
 		name = ModuleFuelTanks

--- a/RealFuels/Resources/ResourceHsps.cfg
+++ b/RealFuels/Resources/ResourceHsps.cfg
@@ -171,7 +171,7 @@
 }
 
 // Nitric Acid
-@RESOURCE_DEFINITION[IRFNA*|IWFNA||AK20|AK27]:FOR[RealFuels]
+@RESOURCE_DEFINITION[IRFNA*|IWFNA|AK20|AK27]:FOR[RealFuels]
 {
 	%hsp = 1720 // specific heat capacity (kJ/tonne-K as units) // http://www.engineeringtoolbox.com/specific-heat-fluids-d_151.html for nitric acid, copied to AKx
 }


### PR DESCRIPTION
Hi @NathanKell,

This is like KSP-RO/RealismOverhaul#2612 but for RealFuels.
Referencing KSP-CKAN/CKAN/pull/3525 so I can find this again later easily.

Just two fixes: a deletion with a missing `{}`, and an extra `|`.
