### PR TITLE
Fix MM syntax errors

### DIFF
--- a/RealFuels/Resources/ResourceHsps.cfg
+++ b/RealFuels/Resources/ResourceHsps.cfg
@@ -108,12 +108,12 @@
 	//hsp in CRP correct
 	%vsp = 1193640
 }
-@RESOURCE_DEFINITION[Ethanol90]:FOR[RealismOverhaul]
+@RESOURCE_DEFINITION[Ethanol90]:NEEDS[RealismOverhaul]
 {
 	//hsp in CRP correct
 	%vsp = 952612
 }
-@RESOURCE_DEFINITION[Ethanol]:FOR[RealismOverhaul]
+@RESOURCE_DEFINITION[Ethanol]:NEEDS[RealismOverhaul]
 {
 	//hsp in CRP correct
 	%vsp = 839187


### PR DESCRIPTION
Incorrect use of :FOR[RealismOverhaul], which lets other MM patches believe RO is installed anyway.

Reference from [MM's forum page](https://forum.kerbalspaceprogram.com/index.php?/topic/50533-18x-112x-module-manager-421-august-1st-2021-locked-inside-edition/&do=findComment&comment=720815):
:FOR[ModName] - I am ModName, and these are my patches.
:NEEDS[ModName1] - execute this patch only if ModName1 is installed.

Example of affected patches:
[MechJebNoCommandPod.cfg from MechJeb 2](https://github.com/MuMech/MechJeb2/blob/f5c1193813da7d2e2e347f963dd4ee4b7fb11a90/Parts/MechJebNoCommandPod.cfg)
`@PART[*]:HAS[@MODULE[ModuleCommand],!MODULE[KerbalEVA]]:NEEDS[!MechJebUseCommandPod,!RP-0,!RealismOverhaul]`