### PR TITLE
Remove references to RO

### DIFF
--- a/RealFuels/Resources/ResourceHsps.cfg
+++ b/RealFuels/Resources/ResourceHsps.cfg
@@ -108,12 +108,12 @@
 	//hsp in CRP correct
 	%vsp = 1193640
 }
-@RESOURCE_DEFINITION[Ethanol90]:FOR[RealismOverhaul]
+@RESOURCE_DEFINITION[Ethanol90]:FOR[RealFuels]
 {
 	//hsp in CRP correct
 	%vsp = 952612
 }
-@RESOURCE_DEFINITION[Ethanol]:FOR[RealismOverhaul]
+@RESOURCE_DEFINITION[Ethanol]:FOR[RealFuels]
 {
 	//hsp in CRP correct
 	%vsp = 839187


### PR DESCRIPTION
Remove MM patches that incorrectly used `:FOR[RealismOverhaul]`
Resolves https://github.com/NathanKell/ModularFuelSystem/pull/290