### PR TITLE
Update Aniline22 and Aniline37 fuel

### DIFF
--- a/RealFuels/Resources/RealTankTypes.cfg
+++ b/RealFuels/Resources/RealTankTypes.cfg
@@ -127,6 +127,24 @@ TANK_DEFINITION
 	}
 	TANK
 	{
+		name = Aniline22
+		mass = 0.00002
+		utilization = 1
+		fillable = True
+		amount = 0.0
+		maxAmount = 0.0
+	}
+	TANK
+	{
+		name = Aniline37
+		mass = 0.00002
+		utilization = 1
+		fillable = True
+		amount = 0.0
+		maxAmount = 0.0
+	}
+	TANK
+	{
 		name = Ethanol75
 		mass = 0.000013
 		utilization = 1
@@ -616,6 +634,24 @@ TANK_DEFINITION
 	TANK
 	{
 		name = Aniline
+		mass = 0.00002
+		utilization = 1
+		fillable = True
+		amount = 0.0
+		maxAmount = 0.0
+	}
+	TANK
+	{
+		name = Aniline22
+		mass = 0.00002
+		utilization = 1
+		fillable = True
+		amount = 0.0
+		maxAmount = 0.0
+	}
+	TANK
+	{
+		name = Aniline37
 		mass = 0.00002
 		utilization = 1
 		fillable = True
@@ -1145,6 +1181,26 @@ TANK_DEFINITION
 	{
 		name = Aniline
 		mass = 0.000085
+		utilization = 1
+		fillable = True
+		amount = 0.0
+		maxAmount = 0.0
+		note = (pressurized)
+	}
+	TANK
+	{
+		name = Aniline22
+		mass = 0.00002
+		utilization = 1
+		fillable = True
+		amount = 0.0
+		maxAmount = 0.0
+		note = (pressurized)
+	}
+	TANK
+	{
+		name = Aniline37
+		mass = 0.00002
 		utilization = 1
 		fillable = True
 		amount = 0.0
@@ -1849,6 +1905,24 @@ TANK_DEFINITION
 	}
 	TANK
 	{
+		name = Aniline22
+		mass = 0.00002
+		utilization = 1
+		fillable = True
+		amount = 0.0
+		maxAmount = 0.0
+	}
+	TANK
+	{
+		name = Aniline37
+		mass = 0.00002
+		utilization = 1
+		fillable = True
+		amount = 0.0
+		maxAmount = 0.0
+	}
+	TANK
+	{
 		name = Ethanol75
 		mass = 0.000013
 		utilization = 1
@@ -2370,6 +2444,26 @@ TANK_DEFINITION
 	{
 		name = Aniline
 		mass = 0.000085
+		utilization = 1
+		fillable = True
+		amount = 0.0
+		maxAmount = 0.0
+		note = (pressurized)
+	}
+	TANK
+	{
+		name = Aniline22
+		mass = 0.00002
+		utilization = 1
+		fillable = True
+		amount = 0.0
+		maxAmount = 0.0
+		note = (pressurized)
+	}
+	TANK
+	{
+		name = Aniline37
+		mass = 0.00002
 		utilization = 1
 		fillable = True
 		amount = 0.0
@@ -3078,6 +3172,24 @@ TANK_DEFINITION
 	}
 	TANK
 	{
+		name = Aniline22
+		mass = 0.00002
+		utilization = 1
+		fillable = True
+		amount = 0.0
+		maxAmount = 0.0
+	}
+	TANK
+	{
+		name = Aniline37
+		mass = 0.00002
+		utilization = 1
+		fillable = True
+		amount = 0.0
+		maxAmount = 0.0
+	}
+	TANK
+	{
 		name = Ethanol75
 		mass = 0.000013
 		utilization = 1
@@ -3567,6 +3679,24 @@ TANK_DEFINITION
 	TANK
 	{
 		name = Aniline
+		mass = 0.00002
+		utilization = 1
+		fillable = True
+		amount = 0.0
+		maxAmount = 0.0
+	}
+	TANK
+	{
+		name = Aniline22
+		mass = 0.00002
+		utilization = 1
+		fillable = True
+		amount = 0.0
+		maxAmount = 0.0
+	}
+	TANK
+	{
+		name = Aniline37
 		mass = 0.00002
 		utilization = 1
 		fillable = True


### PR DESCRIPTION
In [ROEngines](https://github.com/KSP-RO/ROEngines) and [Taerobee](https://github.com/Peter-JY/Taerobee), the engine Aerobee need Aniline22 as fuel. But in RealFuel, there isn't a fuel called Aniline22 as well as Aniline37, which is used in RO (You can see it [here](https://github.com/KSP-RO/RealismOverhaul/blob/master/GameData/RealismOverhaul/RO_RealFuels.cfg#L783)). So I update these two fuels to RF, and create this pull request.

After several tests, now I can use Aerobee engine in KSP 1.12.1 with the fuel Aniline22.