### PR TITLE
Exclude Ablator, Uranium

### DIFF
--- a/RealFuels/MFSSettings.cfg
+++ b/RealFuels/MFSSettings.cfg
@@ -15,5 +15,8 @@ MFSSETTINGS
 		U235Rods = True
 		DepU235Rods = True
 		ElectricCharge = True
+		Ablator = True
+		EnrichedUranium = True
+		UraniumNitride = True
 	}
 }


### PR DESCRIPTION
Exclude Ablator, Enriched Uranium and Uranium Nitride from RF auto-fill so it works correctly with the RS-68 and NTRs.