### PR TITLE
Change how tank masses are calculated

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
-Dont download this, i broke it, tank masses dont calculate properly, will do more work on the problem soon and try to come up with an actual solution thats not just deleting a variable
+needs review
+Tank masses used to be calculated improperly, using the whole volume of the tank, instead of an area or wall volume, causing the tank's dry mass to increase as a cube, resulting in very poor performance in large rockets.
 
-update 1:
-- added some math, might work idk, testing when i can figure out how to compile this god forsaken program on Windows
+The new method is to calculate the wall volume of a spherical tank, then apply an aluminum density to it, resulting in an accurate dry mass, similar to numbers irl.
+The method is not incredibly accurate, but it is a quick and dirty patch, so hopefully someone more skilled & knowledgeable of the codebase takes on the task to optimize and clean it up/make it play nice with older code.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,0 @@
-Hotfix, needs review
-
-Tank masses used to be calculated improperly, using the whole volume of the tank, instead of an area or wall volume, causing the tank's dry mass to increase as a cube, resulting in very poor performance in large rockets.
-
-The new method is to calculate the wall volume of a spherical tank, then apply an aluminum density to it, resulting in an accurate dry mass, similar to numbers irl.
-The method is not incredibly accurate, but it is a quick and dirty patch, so hopefully someone more skilled & knowledgeable of the codebase takes on the task to optimize and clean it up/make it play nice with older code.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
-needs review
+Hotfix, needs review
+
 Tank masses used to be calculated improperly, using the whole volume of the tank, instead of an area or wall volume, causing the tank's dry mass to increase as a cube, resulting in very poor performance in large rockets.
 
 The new method is to calculate the wall volume of a spherical tank, then apply an aluminum density to it, resulting in an accurate dry mass, similar to numbers irl.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,1 @@
+Dont download this, i broke it, tank masses dont calculate properly

--- a/README.md
+++ b/README.md
@@ -1,1 +1,1 @@
-Dont download this, i broke it, tank masses dont calculate properly
+Dont download this, i broke it, tank masses dont calculate properly, will do more work on the problem soon and try to come up with an actual solution thats not just deleting a variable

--- a/README.md
+++ b/README.md
@@ -1,1 +1,4 @@
 Dont download this, i broke it, tank masses dont calculate properly, will do more work on the problem soon and try to come up with an actual solution thats not just deleting a variable
+
+update 1:
+- added some math, might work idk, testing when i can figure out how to compile this god forsaken program on Windows

--- a/Source/Tanks/ModuleFuelTanks.cs
+++ b/Source/Tanks/ModuleFuelTanks.cs
@@ -774,6 +774,14 @@ namespace RealFuels.Tanks
             }
         }
 
+        //Here's the function I'm adding to calculate the volume of a hollow, spherical tank. Instead of the whole tank volume, you psychos...
+        public double TankWallVolume (float OldVolume)
+        {
+            double radius = Math.Pow(OldVolume * 0.001 * 0.75f / Math.PI, 1f / 3);
+            double dV = (4 / 3) * Math.PI * Math.Pow(radius - .004, 2);
+            return OldVolume - dV;
+        }
+
         public void CalculateMass ()
         {
             if (!massDirty)
@@ -787,7 +795,7 @@ namespace RealFuels.Tanks
 
             if (basemass >= 0)
             {
-                double tankDryMass = tanksDict.Values.Sum(t => t.Volume * t.mass);
+                double tankDryMass = tanksDict.Values.Sum(t => TankWallVolume(t.Volume) * t.mass);
                 mass = (float) ((basemass + tankDryMass) * MassMult);
             }
             else

--- a/Source/Tanks/ModuleFuelTanks.cs
+++ b/Source/Tanks/ModuleFuelTanks.cs
@@ -774,11 +774,17 @@ namespace RealFuels.Tanks
             }
         }
 
-        //Here's the function I'm adding to calculate the volume of a hollow, spherical tank. Instead of the whole tank volume, you psychos...
-        public double TankWallVolume (float OldVolume)
+ // heres the function im adding to calculate the wall volume of a hollow, spherical tank
+        // not accurate for cylindrical volumes but inspired by a method i found in modulefueltanksRF
+
+        public double TankWallVolume (double OldVolume)
         {
+            //stole this one line from modulefueltanksRF <3
             double radius = Math.Pow(OldVolume * 0.001 * 0.75f / Math.PI, 1f / 3);
-            double dV = (4 / 3) * Math.PI * Math.Pow(radius - .004, 2);
+            // calculates volume of sphere slightly smaller 4mm in radius than the previous volume
+            //then converts from m^3 to L
+            double dV = 1.33 * Math.PI * Math.Pow((radius - 0.004), 3f) * 1000;
+            //the dry mas resides in the volume between the two
             return OldVolume - dV;
         }
 
@@ -789,14 +795,34 @@ namespace RealFuels.Tanks
                 return;
             }
             massDirty = false;
+            /*
+            -also changing t.mass to be a static 2.71 kg/l for an aerospace alluminum alloy 
+
+            -2195 was used as the alloy for the space shuttle main tank so I'll use that as the model : using matweb.com as a reference
+
+            it would be really cool if someone more knowledgable made the tech levels change the density so that the player gets 
+            additional mass savings as they progress, as if they are using better alloys 
+            */
+            double density_2195A = 0.00271;
+            //whyyyyyy does ksp use base units of tons bro (its not that bad)
+
+             /*this is the new method i added to calculate tank mass, its accurate to a few percent
+             * but theres probably a lot of error in the way im coding the math and the method im using
+             * isnt 100% accurate for a cylindrical tank, i just wanted better functionality with 
+             * procedural parts tanks so that my tanks didnt weigh 300t dry */
+
+            double tankDryMass = TankWallVolume(totalVolume) * density_2195A;
 
             double basemass = basemassConst + basemassPV * (MFSSettings.basemassUseTotalVolume ? totalVolume : volume);
-            CalculateMassRF(ref basemass);
+            CalculateMassRF(ref tankDryMass);
+
+
 
             if (basemass >= 0)
             {
-                double tankDryMass = tanksDict.Values.Sum(t => TankWallVolume(t.Volume) * t.mass);
-                mass = (float) ((basemass + tankDryMass) * MassMult);
+                mass = (float) (tankDryMass);
+                //afternote, this may be horribly balanced for stock KSP, because now tanks are lighter
+               
             }
             else
             {


### PR DESCRIPTION
Current method causes mass to increase with the cube (volume) of the tank, resulting in very high and unrealistic dry masses for tanks.

Proposed method calculates the wall volume of a hypothetical spherical tank, then multiplies the density of aluminum to calculate a more accurate mass profile.
