### PR TITLE
Use smaller SI prefixes for low thrust engines

### DIFF
--- a/Source/Engines/UI/EngineConfigGUI.cs
+++ b/Source/Engines/UI/EngineConfigGUI.cs
@@ -460,7 +460,7 @@ namespace RealFuels
         private void DrawHeaderRow(Rect headerRect)
         {
             float currentX = headerRect.x;
-            
+
             // Dynamic header and tooltip for survival column based on mode
             string survivalHeader;
             string survivalTooltip;
@@ -873,6 +873,10 @@ namespace RealFuels
             float thrust = _module.scale * _techLevels.ThrustTL(node.GetValue(_module.thrustRating), node);
             if (thrust >= 100f)
                 return $"{thrust:N0} kN";
+            if (thrust < 1e-3f)
+                return $"{thrust * 1e6f:N0} mN";
+            if (thrust < 0.01f)
+                return $"{thrust * 1e3f:N0} N";
             return $"{thrust:N2} kN";
         }
 
@@ -1098,11 +1102,11 @@ namespace RealFuels
             {
                 // Percentage mode: show TIME to reach the selected percentage
                 float targetProb = sliderPercentage / 100f;
-                
+
                 // Find time for start and end reliability (no clustering/ignition for table display)
                 float timeStart = ChartMath.FindTimeForSurvivalProb(targetProb, ratedBurnTime, cycleReliabilityStart, cycleCurve, 10000f);
                 float timeEnd = ChartMath.FindTimeForSurvivalProb(targetProb, ratedBurnTime, cycleReliabilityEnd, cycleCurve, 10000f);
-                
+
                 return $"<color={fadedOrange}>{ChartMath.FormatTime(timeStart)}</color> / <color={fadedGreen}>{ChartMath.FormatTime(timeEnd)}</color>";
             }
             else

--- a/Source/Engines/UI/EngineConfigGUI.cs
+++ b/Source/Engines/UI/EngineConfigGUI.cs
@@ -1106,6 +1106,10 @@ namespace RealFuels
             float thrust = _module.scale * _techLevels.ThrustTL(node.GetValue(_module.thrustRating), node);
             if (thrust >= 100f)
                 return $"{thrust:N0} kN";
+            if (thrust < 1e-3f)
+                return $"{thrust * 1e6f:N0} mN";
+            if (thrust < 0.01f)
+                return $"{thrust * 1e3f:N0} N";
             return $"{thrust:N2} kN";
         }
 

--- a/Source/Engines/UI/EngineConfigGUI.cs
+++ b/Source/Engines/UI/EngineConfigGUI.cs
@@ -1106,7 +1106,7 @@ namespace RealFuels
             float thrust = _module.scale * _techLevels.ThrustTL(node.GetValue(_module.thrustRating), node);
             if (thrust >= 100f)
                 return $"{thrust:N0} kN";
-            if (thrust < 0.01f || thrust > 100000f)
+            if (thrust < 0.01f)
                 return KSPUtil.PrintSI(thrust * 1e3f, "N", 3);
             return $"{thrust:N2} kN";
         }

--- a/Source/Engines/UI/EngineConfigGUI.cs
+++ b/Source/Engines/UI/EngineConfigGUI.cs
@@ -1106,10 +1106,8 @@ namespace RealFuels
             float thrust = _module.scale * _techLevels.ThrustTL(node.GetValue(_module.thrustRating), node);
             if (thrust >= 100f)
                 return $"{thrust:N0} kN";
-            if (thrust < 1e-3f)
-                return $"{thrust * 1e6f:N0} mN";
-            if (thrust < 0.01f)
-                return $"{thrust * 1e3f:N0} N";
+            if (thrust < 0.01f || thrust > 100000f)
+                return KSPUtil.PrintSI(thrust * 1e3f, "N", 3);
             return $"{thrust:N2} kN";
         }
 


### PR DESCRIPTION
Small PR to display thrust in N or mN for low thrust engines in the editor EngineConfig window. At the moment the only engines I could find where this crops up are the ion engines:

<img width="1002" height="244" alt="Screenshot_20260603_172103" src="https://github.com/user-attachments/assets/373f09b6-ce33-4728-bcf6-6a7d6dd39e61" />


I saw ryam suggest this in the RP-1 discord dev-feedback channel and figured I could try my hand at it.

